### PR TITLE
Allow plugins to expose a different content type (e.g. text/html)

### DIFF
--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -34,7 +34,7 @@ from datetime import datetime
 import cherrypy
 
 
-def om_expose(method=None, auth=True):
+def om_expose(method=None, auth=True, content_type='application/json'):
     """ Decorator to expose a method of the plugin class through the
     webinterface. The url will be /plugins/<plugin-name>/<method>.
 
@@ -60,13 +60,15 @@ def om_expose(method=None, auth=True):
             def _exposed(self, token, *args, **kwargs):
                 """ Exposed with token. """
                 self.webinterface.check_token(token)
-                cherrypy.response.headers["Content-Type"] = "application/json"
-                return method(self, *args, **kwargs)
+                result = method(self, *args, **kwargs)
+                cherrypy.response.headers["Content-Type"] = content_type
+                return result
         else:
             def _exposed(*args, **kwargs):
                 """ Exposed without token. """
-                cherrypy.response.headers["Content-Type"] = "application/json"
-                return method(*args, **kwargs)
+                result = method(*args, **kwargs)
+                cherrypy.response.headers["Content-Type"] = content_type
+                return result
 
         _exposed.exposed = True
         _exposed.auth = auth


### PR DESCRIPTION
Example for a plugin's index page, returning `text/html`.

```python
@om_expose(content_type='text/html')
def html_index(self):
    self.logger('Building HTML')
    try:
        data = json.dumps(json.loads(self.webinterface.get_modules(self.webinterface.dummy_token)), indent=4)
    except CommunicationTimedOutException as ex:
        data = ex
        self.logger('Error getting modules: CommunicationTimedOutException')
    except Exception as ex:
        data = ex
        self.logger('Error getting modules: {0}'.format(ex))
    html = '<html><head><title>Example</title></head><body><pre>{0}</pre></body></html>'.format(data)
    self.logger('Return HTML')
    return html
```

Also note the requirement to pass `self.webinterface.dummy_token` as token, instead of `None` elsewhere in the plugins.