### PR TITLE
ensure core communicator CIDs are discarded

### DIFF
--- a/testing/unittests/master_core_tests/core_communicator_tests.py
+++ b/testing/unittests/master_core_tests/core_communicator_tests.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2019 OpenMotics BV
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import unittest
+
+import mock
+import xmlrunner
+
+import master_core.core_communicator
+from ioc import SetTestMode, SetUpTestInjections
+from master_core.core_communicator import Consumer, CoreCommunicator
+
+
+class CoreCommunicatorTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        SetTestMode()
+
+    def test_do_command_exception_discard_cid(self):
+        communicator = CoreCommunicator(controller_serial=mock.Mock())
+        with mock.patch.object(communicator, 'discard_cid') as discard:
+            self.assertRaises(AttributeError, communicator.do_command, None, {})
+            discard.assert_called_with(2)
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=xmlrunner.XMLTestRunner(output='../gw-unit-reports'))

--- a/testing/unittests/run.sh
+++ b/testing/unittests/run.sh
@@ -58,5 +58,8 @@ python2 master_core_tests/memory_file_tests.py
 echo "Running Core api field tests"
 python2 master_core_tests/api_field_tests.py
 
+echo "running Core communicator tests"
+python2 master_core_tests/core_communicator_tests.py
+
 echo "Running metrics tests"
 python2 gateway_tests/metrics_tests.py


### PR DESCRIPTION
- When sending the command fails ensure the allocated command identifier
  is discarded, since it wasn't used.

- Also discard the command identifier of messages without a registered
  consumer.