### PR TITLE
use --user instead of --target when installing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+# NOTE: packages that should be removed during deployment should be explicitly
+# uninstalled with pip in `post-update.sh`, otherwise they remain available.
+
 pip == 19.3.1
 hypothesis == 4.57.1
 mock == 2.0.0

--- a/src/platform_utils.py
+++ b/src/platform_utils.py
@@ -245,7 +245,7 @@ class System(object):
     @staticmethod
     def import_libs():
         operating_system = System.get_operating_system()['ID']
-        sys.path.insert(0, '/opt/openmotics/dist-packages/')
+        sys.path.insert(0, '/opt/openmotics/python-deps/lib/python2.7/site-packages')
 
         # Patching where/if required
         if operating_system == System.OS.ANGSTROM:

--- a/src/post-update.sh
+++ b/src/post-update.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
+set -e
+
 OS_DIST=`awk -F= '$1=="ID" { print $2 ;}' /etc/os-release`
 TEMP_DIR=$(mktemp -d -t ci-XXXXXXXX --tmpdir=/opt/openmotics)
-env TMPDIR=$TEMP_DIR python /opt/openmotics/python/libs/pip.whl/pip install --upgrade --target /opt/openmotics/dist-packages --no-index /opt/openmotics/python/libs/$OS_DIST/*.whl
+env TMPDIR=$TEMP_DIR PYTHONUSERBASE=/opt/openmotics/python-deps python2 /opt/openmotics/python/libs/pip.whl/pip install --no-index --user /opt/openmotics/python/libs/$OS_DIST/*.whl
 rm -rf $TEMP_DIR


### PR DESCRIPTION
This makes ensure pip handles upgrade behaviour properly, skipping
already installed packages and upgrading versions that changed.
(assuming wheels for these where shipped)

    Processing ./python/libs/debian/peewee_migrate-1.1.6-py2.py3-none-any.whl
    Requirement already satisfied: cached-property>=1.4.2 in ./python-deps/lib/python2.7/site-packages (from peewee-migrate==1.1.6) (1.5.1)
    Requirement already satisfied: peewee>=3.3.3 in ./python-deps/lib/python2.7/site-packages (from peewee-migrate==1.1.6) (3.13.1)
    Requirement already satisfied: mock>=2.0.0 in ./python-deps/lib/python2.7/site-packages (from peewee-migrate==1.1.6) (3.0.5)
    Requirement already satisfied: click>=6.7 in ./python-deps/lib/python2.7/site-packages (from peewee-migrate==1.1.6) (7.0)
    Requirement already satisfied: funcsigs>=1; python_version < "3.3" in ./python-deps/lib/python2.7/site-packages (from mock>=2.0.0->peewee-migrate==1.1.6) (1.0.2)
    Requirement already satisfied: six in ./python-deps/lib/python2.7/site-packages (from mock>=2.0.0->peewee-migrate==1.1.6) (1.13.0)
    Installing collected packages: peewee-migrate
      Found existing installation: peewee-migrate 1.1.5
        Uninstalling peewee-migrate-1.1.5:
          Successfully uninstalled peewee-migrate-1.1.5
      WARNING: The script pw_migrate is installed in '/opt/openmotics/python-deps/bin' which is not on PATH.
      Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
    Successfully installed peewee-migrate-1.1.6