### PR TITLE
fix MasterCommunicator starting race

### DIFF
--- a/src/master/master_communicator.py
+++ b/src/master/master_communicator.py
@@ -106,8 +106,8 @@ class MasterCommunicator(object):
             self.__serial.timeout = None
 
         if not self.__running:
+            self.__running = True
             self.__read_thread.start()
-        self.__running = True
 
     def stop(self):
         pass  # Not supported/used


### PR DESCRIPTION
Ensure self.__running is true before the reader thread starts, otherwise
the thread can just skip the loop and exit immediately.