### PR TITLE
fix typo in GatewayAPI.set_sensor_configuration

### DIFF
--- a/src/gateway/gateway_api.py
+++ b/src/gateway/gateway_api.py
@@ -337,7 +337,7 @@ class GatewayApi(object):
         """
         # TODO: work with sensor controller
         # TODO: add other sensors too (e.g. from database <-- plugins)
-        return self.__master_controller.save_sensor([config])
+        return self.__master_controller.save_sensors([config])
 
     def set_sensor_configurations(self, config):
         """


### PR DESCRIPTION
(cherry picked from commit f1c1c9ee5357bee6394d809a0a08dea176ebaa6f)