### PR TITLE
toolbox: print all gateway logging before starting the tests

### DIFF
--- a/testing/cicd/tests/conftest.py
+++ b/testing/cicd/tests/conftest.py
@@ -23,6 +23,7 @@ settings.load_profile(os.getenv('HYPOTHESIS_PROFILE', 'default'))
 def toolbox_session():
     toolbox = Toolbox()
     toolbox.initialize()
+    toolbox.print_logs()
     return toolbox
 
 
@@ -31,9 +32,4 @@ def toolbox(toolbox_session):
     toolbox = toolbox_session
     toolbox.tester.get('/plugins/syslog_receiver/reset', success=False)
     yield toolbox
-    try:
-        data = toolbox.tester.get('/plugins/syslog_receiver/logs', success=False)
-        for log in data['logs']:
-            print(log)
-    except Exception:
-        print('Failed to retrieve logs')
+    toolbox.print_logs()

--- a/testing/cicd/tests/toolbox.py
+++ b/testing/cicd/tests/toolbox.py
@@ -223,6 +223,15 @@ class Toolbox(object):
             time.sleep(2)
             self.dut.get('/module_discover_stop')
 
+    def print_logs(self):
+        # type: () -> None
+        try:
+            data = self.tester.get('/plugins/syslog_receiver/logs', success=False)
+            for log in data['logs']:
+                print(log)
+        except Exception:
+            print('Failed to retrieve logs')
+
     def factory_reset(self, confirm=True):
         # type: (bool) -> Dict[str,Any]
         assert self.dut._auth


### PR DESCRIPTION
This can include unrelated logs from before the tests, however it will also
include the deployment and startup logs which can be useful if a service
doesn't start properly.
