### PR TITLE
remove classic/core+ singletons

### DIFF
--- a/src/gateway/hal/master_controller_classic.py
+++ b/src/gateway/hal/master_controller_classic.py
@@ -38,10 +38,10 @@ from gateway.hal.mappers_classic import (
 from gateway.hal.master_controller import MasterController
 from gateway.hal.master_event import MasterEvent
 from gateway.maintenance_communicator import InMaintenanceModeException
-from ioc import INJECTED, Inject, Injectable, Singleton
+from ioc import INJECTED, Inject
 from master.classic import eeprom_models, master_api
 from master.classic.eeprom_models import (
-    CanLedConfiguration, DimmerConfiguration, GroupActionConfiguration,
+    CanLedConfiguration, DimmerConfiguration,
     ScheduledActionConfiguration, StartupActionConfiguration
 )
 from master.classic.eeprom_controller import EepromAddress
@@ -60,8 +60,6 @@ if False:  # MYPY
 logger = logging.getLogger("openmotics")
 
 
-@Injectable.named('master_controller')
-@Singleton
 class MasterClassicController(MasterController):
 
     @Inject

--- a/src/gateway/hal/master_controller_core.py
+++ b/src/gateway/hal/master_controller_core.py
@@ -36,7 +36,7 @@ from gateway.hal.mappers_core import (
 from gateway.hal.master_controller import MasterController
 from gateway.hal.master_event import MasterEvent
 from gateway.maintenance_communicator import InMaintenanceModeException
-from ioc import INJECTED, Inject, Injectable, Singleton
+from ioc import INJECTED, Inject
 from master.core.core_api import CoreAPI
 from master.core.core_communicator import BackgroundConsumer, CoreCommunicator
 from master.core.ucan_communicator import UCANCommunicator
@@ -56,8 +56,6 @@ if False:  # MYPY
 logger = logging.getLogger("openmotics")
 
 
-@Injectable.named('master_controller')
-@Singleton
 class MasterCoreController(MasterController):
 
     @Inject

--- a/src/master/classic/maintenance.py
+++ b/src/master/classic/maintenance.py
@@ -20,14 +20,12 @@ from __future__ import absolute_import
 import time
 import logging
 from threading import Timer, Thread
-from ioc import Injectable, Inject, INJECTED, Singleton
+from ioc import Inject, INJECTED
 from gateway.maintenance_communicator import MaintenanceCommunicator
 
 logger = logging.getLogger('openmotics')
 
 
-@Injectable.named('maintenance_communicator')
-@Singleton
 class MaintenanceClassicCommunicator(MaintenanceCommunicator):
     """
     The maintenance communicator handles maintenance communication with the Master

--- a/src/master/classic/master_communicator.py
+++ b/src/master/classic/master_communicator.py
@@ -23,7 +23,7 @@ import time
 from threading import Event, Lock, Thread
 
 from gateway.maintenance_communicator import InMaintenanceModeException
-from ioc import INJECTED, Inject, Injectable, Singleton
+from ioc import INJECTED, Inject
 from master.classic import master_api
 from master.classic.master_command import Field, printable
 from serial_utils import CommunicationTimedOutException
@@ -32,8 +32,6 @@ from toolbox import Empty, Queue
 logger = logging.getLogger("openmotics")
 
 
-@Injectable.named('master_communicator')
-@Singleton
 class MasterCommunicator(object):
     """
     Uses a serial port to communicate with the master and updates the output state.

--- a/src/master/core/core_communicator.py
+++ b/src/master/core/core_communicator.py
@@ -22,7 +22,7 @@ import logging
 import time
 from threading import Thread, Lock
 from six.moves.queue import Queue, Empty
-from ioc import Injectable, Inject, INJECTED, Singleton
+from ioc import Inject, INJECTED
 from master.core.core_api import CoreAPI
 from master.core.fields import WordField
 from master.core.core_command import CoreCommandSpec
@@ -34,8 +34,6 @@ if False:  # MYPY
 logger = logging.getLogger('openmotics')
 
 
-@Injectable.named('master_communicator')
-@Singleton
 class CoreCommunicator(object):
     """
     Uses a serial port to communicate with the Core and updates the output state.

--- a/src/master/core/maintenance.py
+++ b/src/master/core/maintenance.py
@@ -20,14 +20,12 @@ from __future__ import absolute_import
 import time
 import logging
 from threading import Thread, Lock
-from ioc import Injectable, Inject, INJECTED, Singleton
+from ioc import Inject, INJECTED
 from gateway.maintenance_communicator import MaintenanceCommunicator
 
 logger = logging.getLogger('openmotics')
 
 
-@Injectable.named('maintenance_communicator')
-@Singleton
 class MaintenanceCoreCommunicator(MaintenanceCommunicator):
 
     @Inject

--- a/src/master_tool.py
+++ b/src/master_tool.py
@@ -18,7 +18,8 @@ Tool to control the master from the command line.
 @author: fryckbos
 """
 from __future__ import absolute_import
-from platform_utils import System, Platform
+from platform_utils import Platform, System
+
 System.import_libs()
 
 import argparse
@@ -27,13 +28,21 @@ import shutil
 import subprocess
 import sys
 import time
-from six.moves.configparser import ConfigParser
-from ioc import INJECTED, Inject, Injectable
+
 from serial import Serial
+from six.moves.configparser import ConfigParser
+
 import constants
 import master.classic.master_api as master_api
+from gateway.hal.master_controller_classic import MasterClassicController
+from gateway.hal.master_controller_core import MasterCoreController
+from ioc import INJECTED, Inject, Injectable
+from master.classic.master_communicator import MasterCommunicator
 from master.core.core_api import CoreAPI
+from master.core.core_communicator import CoreCommunicator
+from master.core.memory_file import MemoryFile, MemoryTypes
 from serial_utils import CommunicationTimedOutException
+
 
 logger = logging.getLogger('openmotics')
 
@@ -165,18 +174,23 @@ def main():
 
     Injectable.value(controller_serial=Serial(port, 115200))
 
+    # TODO use platform_setup?
     if platform == Platform.Type.CORE_PLUS:
-        from master.core.memory_file import MemoryFile, MemoryTypes
+        from master.core import ucan_communicator
+        _ = ucan_communicator
+        Injectable.value(master_communicator=CoreCommunicator())
+        Injectable.value(maintenance_communicator=None)
         Injectable.value(memory_files={MemoryTypes.EEPROM: MemoryFile(MemoryTypes.EEPROM),
                                        MemoryTypes.FRAM: MemoryFile(MemoryTypes.FRAM)})
-        from gateway.hal import master_controller_core
-        _ = master_controller_core
+        Injectable.value(master_controller=MasterCoreController())
     else:
         Injectable.value(configuration_controller=None)
         Injectable.value(eeprom_db=constants.get_eeprom_extension_database_file())
         from master.classic import eeprom_extension
-        from gateway.hal import master_controller_classic
-        _ = master_controller_classic
+        _ = eeprom_extension
+        Injectable.value(master_communicator=MasterCommunicator())
+        Injectable.value(maintenance_communicator=None)
+        Injectable.value(master_controller=MasterClassicController())
 
     if args.hardreset:
         master_cold_reset()


### PR DESCRIPTION
Having overlapping singleton registrations meant that the classic and
core+ modules couldn't be imported at the same time. This means code
needs to be carefully imported depending on what platform is being
tested, particularly problematic for testing.