### PR TITLE
set default config values when not defined

### DIFF
--- a/src/gateway/config.py
+++ b/src/gateway/config.py
@@ -72,7 +72,7 @@ class ConfigurationController(object):
                                    'cloud_support': False,
                                    'cors_enabled': False}.items():
             if self.get(key) is None:
-                self.get(key, default_value)
+                self.set(key, default_value)
 
     def get(self, key, fallback=None):
         for entry in self.__execute('SELECT data FROM settings WHERE setting=?;', (key.lower(),)):

--- a/src/gateway/metrics_controller.py
+++ b/src/gateway/metrics_controller.py
@@ -531,6 +531,7 @@ class MetricsController(object):
                 try:
                     receiver(metric)
                 except Exception as ex:
+                    logger.exception('error distributing metrics')
                     raise MetricsDistributeFailed('Error distributing metrics to internal receivers: {0}'.format(ex))
                 rate_key = '{0}.{1}'.format(metric['source'].lower(), metric['type'].lower())
                 if rate_key not in self.outbound_rates:


### PR DESCRIPTION
Looks tike this was the intention, otherwise eg. the metrics controller
can receive None instead of an empty list, which isn't handled.

    Traceback (most recent call last):
      File "/opt/openmotics/python-develop/gateway/metrics_controller.py", line 533, in _distribute_openmotics
        receiver(metric)
      File "/opt/openmotics/python-develop/gateway/metrics_controller.py", line 309, in receiver
        if not self._needs_upload_to_cloud(metric):
      File "/opt/openmotics/python-develop/gateway/metrics_controller.py", line 277, in _needs_upload_to_cloud
        if metric_type not in metric_types:
    TypeError: argument of type 'NoneType' is not iterable