### PR TITLE
mark slow testcases

### DIFF
--- a/testing/unittests/gateway_tests/users_test.py
+++ b/testing/unittests/gateway_tests/users_test.py
@@ -19,12 +19,16 @@ Tests for the users module.
 """
 
 from __future__ import absolute_import
-import unittest
-import xmlrunner
+
 import time
+import unittest
 from threading import Lock
-from ioc import SetTestMode, SetUpTestInjections
+
+import xmlrunner
+from pytest import mark
+
 from gateway.users import UserController
+from ioc import SetTestMode, SetUpTestInjections
 
 
 class UserControllerTest(unittest.TestCase):
@@ -87,6 +91,7 @@ class UserControllerTest(unittest.TestCase):
 
         self.assertEqual('admin', user_controller.get_role('fred'))
 
+    @mark.slow
     def test_token_timeout(self):
         """ Test the timeout on the tokens. """
         SetUpTestInjections(config={'username': 'om', 'password': 'pass'},

--- a/testing/unittests/master_tests/inputs_test.py
+++ b/testing/unittests/master_tests/inputs_test.py
@@ -17,11 +17,14 @@ Tests for InputStatus.
 """
 
 from __future__ import absolute_import
+
 import time
 import unittest
 
 import mock
 import xmlrunner
+from pytest import mark
+
 from master.classic.inputs import InputStatus
 
 
@@ -102,6 +105,7 @@ class InputStatusTest(unittest.TestCase):
         self.assertEqual(current_status['status'], None)
         self.assertEqual(len(changed), 2)
 
+    @mark.slow
     def test_timeout(self):
         """ Test timeout of InputStatus data. """
         inps = InputStatus(5, 1)

--- a/testing/unittests/master_tests/master_communicator_test.py
+++ b/testing/unittests/master_tests/master_communicator_test.py
@@ -23,6 +23,7 @@ import time
 import unittest
 
 import xmlrunner
+from pytest import mark
 
 from gateway.maintenance_communicator import InMaintenanceModeException
 from ioc import SetTestMode, SetUpTestInjections
@@ -54,6 +55,7 @@ class MasterCommunicatorTest(unittest.TestCase):
         output = comm.do_command(action, fields)
         self.assertEqual('OK', output['resp'])
 
+    @mark.slow
     def test_timeout(self):
         action = master_api.basic_action()
         fields = {'action_type': 1, 'action_number': 2}
@@ -84,6 +86,7 @@ class MasterCommunicatorTest(unittest.TestCase):
         output = comm.do_command(action, fields)
         self.assertEqual('OK', output['resp'])
 
+    @mark.slow
     def test_split_data(self):
         action = master_api.basic_action()
         fields = {'action_type': 1, 'action_number': 2}

--- a/testing/unittests/plugins_tests/base_test.py
+++ b/testing/unittests/plugins_tests/base_test.py
@@ -17,19 +17,22 @@ Tests for plugins.base.
 """
 
 from __future__ import absolute_import
+
 import hashlib
 import inspect
 import os
-import plugin_runtime
 import shutil
 import tempfile
 import time
 import unittest
-import xmlrunner
-from mock import Mock
 from subprocess import call
-from ioc import SetUpTestInjections, SetTestMode
+
+from mock import Mock
+from pytest import mark
+
+import plugin_runtime
 from gateway.events import GatewayEvent
+from ioc import SetTestMode, SetUpTestInjections
 from plugin_runtime.base import PluginConfigChecker, PluginException
 
 
@@ -107,6 +110,7 @@ class PluginControllerTest(unittest.TestCase):
         finally:
             shutil.rmtree(temp_directory)
 
+    @mark.slow
     def test_get_one_plugin(self):
         """ Test getting one plugin in the plugins package. """
         controller = None
@@ -129,6 +133,7 @@ class P1(OMPluginBase):
                 controller.stop()
             PluginControllerTest._destroy_plugin('P1')
 
+    @mark.slow
     def test_get_two_plugins(self):
         """ Test getting two plugins in the plugins package. """
         controller = None
@@ -163,6 +168,7 @@ class P2(OMPluginBase):
             PluginControllerTest._destroy_plugin('P1')
             PluginControllerTest._destroy_plugin('P2')
 
+    @mark.slow
     def test_get_special_methods(self):
         """ Test getting special methods on a plugin. """
         controller = None
@@ -268,6 +274,7 @@ class P1(OMPluginBase):
                 controller.stop()
             PluginControllerTest._destroy_plugin('P1')
 
+    @mark.slow
     def test_update_plugin(self):
         """ Validates whether a plugin can be updated """
         test_1_md5, test_1_data = PluginControllerTest._create_plugin_package('Test', """
@@ -301,6 +308,7 @@ class Test(OMPluginBase):
         self.assertEqual(result, 'Plugin successfully installed')
         self.assertEqual([r.name for r in controller.get_plugins()], ['Test'])
 
+    @mark.slow
     def test_plugin_metric_reference(self):
         """ Validates whether two plugins won't get the same metric instance """
         controller = None
@@ -729,7 +737,3 @@ class PluginConfigCheckerTest(unittest.TestCase):
             self.assertEqual(arg_spec.args[1:], call_info)
             ramaining_methods.remove(method_name)
         self.assertEqual(ramaining_methods, [])
-
-
-if __name__ == "__main__":
-    unittest.main(testRunner=xmlrunner.XMLTestRunner(output='../gw-unit-reports'))

--- a/testing/unittests/power_tests/power_communicator_test.py
+++ b/testing/unittests/power_tests/power_communicator_test.py
@@ -23,6 +23,7 @@ import time
 import unittest
 
 import xmlrunner
+from pytest import mark
 
 import power.power_api as power_api
 from ioc import SetTestMode, SetUpTestInjections
@@ -137,6 +138,7 @@ class PowerCommunicatorTest(unittest.TestCase):
         with self.assertRaises(Exception):
             comm.do_command(1, action_1)
 
+    @mark.slow
     def test_address_mode(self):
         """ Test the address mode. """
         sad = power_api.set_addressmode(power_api.POWER_MODULE)
@@ -172,6 +174,7 @@ class PowerCommunicatorTest(unittest.TestCase):
         self.assertEqual(controller.get_free_address(), 4)
         self.assertFalse(comm.in_address_mode())
 
+    @mark.slow
     def test_do_command_in_address_mode(self):
         """ Test the behavior of do_command in address mode."""
         action = power_api.get_voltage(power_api.POWER_MODULE)
@@ -201,6 +204,7 @@ class PowerCommunicatorTest(unittest.TestCase):
 
         self.assertEqual((49.5, ), comm.do_command(1, action))
 
+    @mark.slow
     def test_address_mode_timeout(self):
         """ Test address mode timeout. """
         action = power_api.get_voltage(power_api.POWER_MODULE)
@@ -226,6 +230,7 @@ class PowerCommunicatorTest(unittest.TestCase):
 
         self.assertEqual((49.5, ), comm.do_command(1, action))
 
+    @mark.slow
     def test_timekeeper(self):
         """ Test the TimeKeeper. """
         SetUpTestInjections(power_db=PowerCommunicatorTest.FILE)


### PR DESCRIPTION
This makes iterating on tests much faster without having to selectively
figure out which test cases to select.

Reduces the time for a partial run from 39s -> 6s.

    $ pytest -v -m 'not slow' testing/unittests