### PR TITLE
always print logs

### DIFF
--- a/testing/cicd/tests/conftest.py
+++ b/testing/cicd/tests/conftest.py
@@ -22,8 +22,10 @@ settings.load_profile(os.getenv('HYPOTHESIS_PROFILE', 'default'))
 @fixture(scope='session')
 def toolbox_session():
     toolbox = Toolbox()
-    toolbox.initialize()
-    toolbox.print_logs()
+    try:
+        toolbox.initialize()
+    finally:
+        toolbox.print_logs()
     return toolbox
 
 


### PR DESCRIPTION
Include logging even when initialization fails, if there's an issue
before running any tests it's particularly useful to include the service
logging.