### PR TITLE
trigger master synchonization after module discovery

### DIFF
--- a/src/gateway/hal/master_controller_classic.py
+++ b/src/gateway/hal/master_controller_classic.py
@@ -309,6 +309,8 @@ class MasterClassicController(MasterController):
         self._output_last_updated = 0.0
         self._shutters_last_updated = 0.0
 
+        self._synchronization_thread.request_single_run()
+
     def get_firmware_version(self):
         out_dict = self._master_communicator.do_command(master_api.status())
         return int(out_dict['f1']), int(out_dict['f2']), int(out_dict['f3'])
@@ -663,25 +665,19 @@ class MasterClassicController(MasterController):
     def add_virtual_output_module(self):
         # type: () -> str
         module = self._master_communicator.do_command(master_api.add_virtual_module(), {'vmt': 'o'})
-        self._eeprom_controller.invalidate_cache()
-        self._eeprom_controller.dirty = True
-        self._refresh_outputs()
+        self._broadcast_module_discovery()
         return module.get('resp')
 
     def add_virtual_dim_module(self):
         # type: () -> str
         module = self._master_communicator.do_command(master_api.add_virtual_module(), {'vmt': 'd'})
-        self._eeprom_controller.invalidate_cache()
-        self._eeprom_controller.dirty = True
-        self._refresh_outputs()
+        self._broadcast_module_discovery()
         return module.get('resp')
 
     def add_virtual_input_module(self):
         # type: () -> str
         module = self._master_communicator.do_command(master_api.add_virtual_module(), {'vmt': 'i'})
-        self._eeprom_controller.invalidate_cache()
-        self._eeprom_controller.dirty = True
-        self._refresh_inputs()
+        self._broadcast_module_discovery()
         return module.get('resp')
 
     # Generic
@@ -967,13 +963,8 @@ class MasterClassicController(MasterController):
             self._discover_mode_timer.cancel()
             self._discover_mode_timer = None
 
-        self.invalidate_caches()
         self._master_communicator.do_command(master_api.module_discover_stop())
-
-        self._synchronization_thread.request_single_run()
-
-        for callback in self._event_callbacks:
-            callback(MasterEvent(event_type=MasterEvent.Types.MODULE_DISCOVERY, data={}))
+        self._broadcast_module_discovery()
 
         self._module_log = []
 
@@ -983,6 +974,12 @@ class MasterClassicController(MasterController):
     def get_module_log(self):  # type: () -> List[Tuple[str, str]]
         (log, self._module_log) = (self._module_log, [])
         return log
+
+    def _broadcast_module_discovery(self):
+        # type: () -> None
+        self.invalidate_caches()
+        for callback in self._event_callbacks:
+            callback(MasterEvent(event_type=MasterEvent.Types.MODULE_DISCOVERY, data={}))
 
     # Error functions
 

--- a/src/gateway/hal/master_controller_classic.py
+++ b/src/gateway/hal/master_controller_classic.py
@@ -86,10 +86,10 @@ class MasterClassicController(MasterController):
         self._input_last_updated = 0.0
         self._input_config = {}  # type: Dict[int, InputDTO]
         self._output_interval = 600
-        self._output_last_updated = 0
+        self._output_last_updated = 0.0
         self._output_config = {}  # type: Dict[int, OutputDTO]
         self._shutters_interval = 600
-        self._shutters_last_updated = 0
+        self._shutters_last_updated = 0.0
         self._shutter_config = {}  # type: Dict[int, ShutterDTO]
 
         self._discover_mode_timer = None  # type: Optional[Timer]
@@ -305,9 +305,9 @@ class MasterClassicController(MasterController):
         # type: () -> None
         self._eeprom_controller.invalidate_cache()  # Eeprom can be changed in maintenance mode.
         self._eeprom_controller.dirty = True
-        self._input_last_updated = 0
-        self._output_last_updated = 0
-        self._shutters_last_updated = 0
+        self._input_last_updated = 0.0
+        self._output_last_updated = 0.0
+        self._shutters_last_updated = 0.0
 
     def get_firmware_version(self):
         out_dict = self._master_communicator.do_command(master_api.status())
@@ -967,9 +967,10 @@ class MasterClassicController(MasterController):
             self._discover_mode_timer.cancel()
             self._discover_mode_timer = None
 
-        self._eeprom_controller.invalidate_cache()
-        self._eeprom_controller.dirty = True
+        self.invalidate_caches()
         self._master_communicator.do_command(master_api.module_discover_stop())
+
+        self._synchronization_thread.request_single_run()
 
         for callback in self._event_callbacks:
             callback(MasterEvent(event_type=MasterEvent.Types.MODULE_DISCOVERY, data={}))

--- a/testing/cicd/tests/toolbox.py
+++ b/testing/cicd/tests/toolbox.py
@@ -239,15 +239,8 @@ class Toolbox(object):
         # self.list_energy_modules('E')  # TODO: Energy module discovery fails
         self.list_modules('C', hardware=False)  # firmware version missing
 
-        # FIXME: workaround for slow discovery (race condition?)
-        # Toggle all inputs first to push their status.
-        for input in INPUT_MODULE_LAYOUT['I'].inputs:
-            self.tester.toggle_output(input.tester_output_id)
-        time.sleep(10)
+        # TODO ensure discovery synchonization finished.
         self.ensure_input_exists(INPUT_MODULE_LAYOUT['I'].inputs[7], timeout=300)
-        for input in INPUT_MODULE_LAYOUT['C'].inputs:
-            self.tester.toggle_output(input.tester_output_id)
-        time.sleep(10)
         self.ensure_input_exists(INPUT_MODULE_LAYOUT['C'].inputs[5], timeout=300)
 
         try:

--- a/testing/unittests/gateway/hal/master_controller_classic_test.py
+++ b/testing/unittests/gateway/hal/master_controller_classic_test.py
@@ -15,15 +15,20 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from __future__ import absolute_import
+
+import time
 import unittest
+
+import mock
+from pytest import mark
 
 import gateway.hal.master_controller_classic
 import master.classic.master_api
 import master.classic.master_communicator
-import mock
-import xmlrunner
-from ioc import Scope, SetTestMode, SetUpTestInjections
 from gateway.dto import InputDTO
+from gateway.hal.master_controller_classic import MasterClassicController
+from gateway.hal.master_event import MasterEvent
+from ioc import Scope, SetTestMode, SetUpTestInjections
 from master.classic.eeprom_controller import EepromController
 from master.classic.eeprom_models import InputConfiguration
 from master.classic.inputs import InputStatus
@@ -111,7 +116,6 @@ class MasterClassicControllerTest(unittest.TestCase):
             controller.subscribe_event(subscriber.callback)
             new_consumer.assert_called()
             consumer_list[-2].deliver({'input': 1})
-            from gateway.hal.master_event import MasterEvent
             expected_event = MasterEvent.deserialize({'type': 'INPUT_CHANGE',
                                                       'data': {'id': 1,
                                                                'status': True,
@@ -119,29 +123,58 @@ class MasterClassicControllerTest(unittest.TestCase):
             subscriber.callback.assert_called_with(expected_event)
 
     def test_get_inputs_with_status(self):
-        classic = get_classic_controller_dummy()
+        controller = get_classic_controller_dummy()
         with mock.patch.object(InputStatus, 'get_inputs', return_value=[]) as get:
-            classic.get_inputs_with_status()
+            controller.get_inputs_with_status()
             self.assertIn(mock.call(), get.call_args_list)
 
     def test_get_recent_inputs(self):
-        classic = get_classic_controller_dummy()
+        controller = get_classic_controller_dummy()
         with mock.patch.object(InputStatus, 'get_recent', return_value=[]) as get:
-            classic.get_recent_inputs()
+            controller.get_recent_inputs()
             self.assertIn(mock.call(), get.call_args_list)
+
+    def test_module_discover(self):
+        subscriber = mock.Mock()
+        subscriber.callback.return_value = None
+
+        with mock.patch.object(MasterClassicController, 'invalidate_caches') as invalidate, \
+             mock.patch.object(MasterClassicController, '_synchronize') as synchronize:
+            controller = get_classic_controller_dummy([])
+            try:
+                controller.start()
+                controller.module_discover_start(30)
+                time.sleep(0.2)
+                assert len(synchronize.call_args_list) == 1
+
+                controller.subscribe_event(subscriber.callback)
+                invalidate.assert_not_called()
+                controller.module_discover_stop()
+                time.sleep(0.2)
+                assert len(invalidate.call_args_list) == 1
+                assert len(synchronize.call_args_list) == 2
+
+                assert len(subscriber.callback.call_args_list) == 1
+                event = subscriber.callback.call_args_list[0][0][0]
+                assert event.type == MasterEvent.Types.MODULE_DISCOVERY
+            finally:
+                controller.stop()
+
+    def test_module_discover_timeout(self):
+        controller = get_classic_controller_dummy()
+        with mock.patch.object(controller, 'module_discover_stop') as stop:
+            controller.module_discover_start(0)
+            time.sleep(0.2)
+            stop.assert_called_with()
 
 
 @Scope
 def get_classic_controller_dummy(inputs=None):
-    from gateway.hal.master_controller_classic import MasterClassicController
+    communicator_mock = mock.Mock()
     eeprom_mock = mock.Mock(EepromController)
     eeprom_mock.read.return_value = inputs[0] if inputs else []
     eeprom_mock.read_all.return_value = inputs
     SetUpTestInjections(configuration_controller=mock.Mock(),
-                        master_communicator=mock.Mock(),
+                        master_communicator=communicator_mock,
                         eeprom_controller=eeprom_mock)
     return MasterClassicController()
-
-
-if __name__ == "__main__":
-    unittest.main(testRunner=xmlrunner.XMLTestRunner(output='../gw-unit-reports'))

--- a/testing/unittests/gateway/hal/master_controller_classic_test.py
+++ b/testing/unittests/gateway/hal/master_controller_classic_test.py
@@ -138,8 +138,7 @@ class MasterClassicControllerTest(unittest.TestCase):
         subscriber = mock.Mock()
         subscriber.callback.return_value = None
 
-        with mock.patch.object(MasterClassicController, 'invalidate_caches') as invalidate, \
-             mock.patch.object(MasterClassicController, '_synchronize') as synchronize:
+        with mock.patch.object(MasterClassicController, '_synchronize') as synchronize:
             controller = get_classic_controller_dummy([])
             try:
                 controller.start()
@@ -148,10 +147,8 @@ class MasterClassicControllerTest(unittest.TestCase):
                 assert len(synchronize.call_args_list) == 1
 
                 controller.subscribe_event(subscriber.callback)
-                invalidate.assert_not_called()
                 controller.module_discover_stop()
                 time.sleep(0.2)
-                assert len(invalidate.call_args_list) == 1
                 assert len(synchronize.call_args_list) == 2
 
                 assert len(subscriber.callback.call_args_list) == 1
@@ -172,6 +169,7 @@ class MasterClassicControllerTest(unittest.TestCase):
 def get_classic_controller_dummy(inputs=None):
     communicator_mock = mock.Mock()
     eeprom_mock = mock.Mock(EepromController)
+    eeprom_mock.invalidate_cache.return_value = None
     eeprom_mock.read.return_value = inputs[0] if inputs else []
     eeprom_mock.read_all.return_value = inputs
     SetUpTestInjections(configuration_controller=mock.Mock(),


### PR DESCRIPTION
This ensures that the status for modules is updated immediately instead
of with the next synchonization, which can take up to 10 minutes.