### PR TITLE
include DTO type in __repr__

### DIFF
--- a/src/gateway/dto/base.py
+++ b/src/gateway/dto/base.py
@@ -23,4 +23,4 @@ class BaseDTO(object):
         return str(self.__dict__)
 
     def __repr__(self):
-        return str(self.__dict__)
+        return '<{} {}>'.format(self.__class__.__name__, self.__dict__)


### PR DESCRIPTION
This makes it easier to identify the type of the dto, the following
error is rather confusing.

    AssertionError: Lists differ:

    First differing element 0:
    {'id': 1}
    {'id': 1}