### PR TITLE
make communicator do_command covariant over the timeout

### DIFF
--- a/src/gateway/hal/master_controller_classic.py
+++ b/src/gateway/hal/master_controller_classic.py
@@ -71,6 +71,7 @@ class MasterClassicController(MasterController):
                  eeprom_controller=INJECTED):
         # type: (MasterCommunicator, ConfigurationController, EepromController) -> None
         super(MasterClassicController, self).__init__(master_communicator)
+        self._master_communicator = master_communicator  # type: MasterCommunicator
         self._config_controller = configuration_controller
         self._eeprom_controller = eeprom_controller
         self._plugin_controller = None  # type: Optional[Any]
@@ -694,19 +695,19 @@ class MasterClassicController(MasterController):
         # type: () -> str
         module = self._master_communicator.do_command(master_api.add_virtual_module(), {'vmt': 'o'})
         self._broadcast_module_discovery()
-        return module.get('resp')
+        return module['resp']
 
     def add_virtual_dim_module(self):
         # type: () -> str
         module = self._master_communicator.do_command(master_api.add_virtual_module(), {'vmt': 'd'})
         self._broadcast_module_discovery()
-        return module.get('resp')
+        return module['resp']
 
     def add_virtual_input_module(self):
         # type: () -> str
         module = self._master_communicator.do_command(master_api.add_virtual_module(), {'vmt': 'i'})
         self._broadcast_module_discovery()
-        return module.get('resp')
+        return module['resp']
 
     # Generic
 

--- a/src/master/classic/master_communicator.py
+++ b/src/master/classic/master_communicator.py
@@ -31,6 +31,11 @@ from toolbox import Empty, Queue
 
 logger = logging.getLogger("openmotics")
 
+if False:  # MYPY
+    from typing import Any, Dict, List, Optional, TypeVar, Union
+    from master.classic.master_command import MasterCommandSpec
+    T_co = TypeVar('T_co', bound=None, covariant=True)
+
 
 class MasterCommunicator(object):
     """
@@ -165,7 +170,8 @@ class MasterCommunicator(object):
         """
         self.__consumers.append(consumer)
 
-    def do_basic_action(self, action_type, action_number):
+    def do_basic_action(self, action_type, action_number, timeout=2):
+        # type: (int, int, Union[T_co, int]) -> Union[T_co, Dict[str,Any]]
         """
         Sends a basic action to the master with the given action type and action number
         :param action_type: The action type to execute
@@ -184,6 +190,7 @@ class MasterCommunicator(object):
         )
 
     def do_command(self, cmd, fields=None, timeout=2, extended_crc=False):
+        # type: (MasterCommandSpec, Optional[Dict[str,Any]], Union[T_co, int], bool) -> Union[T_co, Dict[str, Any]]
         """ Send a command over the serial port and block until an answer is received.
         If the master does not respond within the timeout period, a CommunicationTimedOutException
         is raised

--- a/src/master/core/core_communicator.py
+++ b/src/master/core/core_communicator.py
@@ -29,7 +29,8 @@ from master.core.core_command import CoreCommandSpec
 from serial_utils import CommunicationTimedOutException, printable
 
 if False:  # MYPY
-    from typing import Optional, Dict, Any
+    from typing import Dict, Any, Optional, TypeVar, Union
+    T_co = TypeVar('T_co', bound=None, covariant=True)
 
 logger = logging.getLogger('openmotics')
 
@@ -186,7 +187,8 @@ class CoreCommunicator(object):
             timeout=timeout
         )
 
-    def do_command(self, command, fields, timeout=2):  # type: (CoreCommandSpec, Dict[str, Any], Optional[int]) -> Optional[Dict[str, Any]]
+    def do_command(self, command, fields, timeout=2):
+        # type: (CoreCommandSpec, Dict[str, Any], Union[T_co, int]) -> Union[T_co, Dict[str, Any]]
         """
         Send a command over the serial port and block until an answer is received.
         If the Core does not respond within the timeout period, a CommunicationTimedOutException is raised
@@ -207,7 +209,7 @@ class CoreCommunicator(object):
             raise
 
         try:
-            result = None
+            result = None  # type: Any
             if isinstance(consumer, Consumer) and timeout is not None:
                 result = consumer.get(timeout)
             self._last_success = time.time()


### PR DESCRIPTION
This makes mypy aware of the fact that do_command always returns a dict
if the timeout is specified and none otherwise.