### PR TITLE
Hotfix - Handle slow bootloader jumps

### DIFF
--- a/src/gateway/__init__.py
+++ b/src/gateway/__init__.py
@@ -14,4 +14,4 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """ Module containing the functionality provided by the gateway. """
 
-__version__ = '2.16.3'
+__version__ = '2.16.4'

--- a/src/gateway/hal/master_controller_classic.py
+++ b/src/gateway/hal/master_controller_classic.py
@@ -869,10 +869,11 @@ class MasterClassicController(MasterController):
         # stay) into bootloader.
         MasterClassicController._set_master_power(False)
         time.sleep(3)
-        subprocess.Popen(['/opt/openmotics/bin/AN1310cl', '-d', port, '-b', baudrate, '-a'],
-                         stdin=subprocess.PIPE,
-                         stdout=subprocess.PIPE)
+        process = subprocess.Popen(['/opt/openmotics/bin/AN1310cl', '-d', port, '-b', baudrate, '-a'],
+                                   stdin=subprocess.PIPE,
+                                   stdout=subprocess.PIPE)
         MasterClassicController._set_master_power(True)
+        process.wait()
 
         logger.info('Verify bootloader...')
         tries = 10
@@ -886,6 +887,7 @@ class MasterClassicController(MasterController):
                     found = True
                     break
             except subprocess.CalledProcessError as ex:
+                response = ex.output  # For debugging purposes down below
                 if ex.returncode != 254:
                     raise
             time.sleep(1)


### PR DESCRIPTION
Wait for the `-a` command before starting the `-s` command