### PR TITLE
delay six import

### DIFF
--- a/src/platform_utils.py
+++ b/src/platform_utils.py
@@ -22,8 +22,6 @@ import os
 import subprocess
 import sys
 
-from six.moves.configparser import ConfigParser
-
 import constants
 
 logger = logging.getLogger('openmotics')
@@ -241,6 +239,7 @@ class Platform(object):
     @staticmethod
     def get_platform():
         # type: () -> str
+        from six.moves.configparser import ConfigParser
         config = ConfigParser()
         config.read(constants.get_config_file())
 


### PR DESCRIPTION
Since platform_utils is used to setup PYTHONPATH it shouldn't depend on
any 3rd party modules as they won't be found until the paths are
configured.