### PR TITLE
fix module_type for module discovery

### DIFF
--- a/src/gateway/hal/master_controller_classic.py
+++ b/src/gateway/hal/master_controller_classic.py
@@ -1337,11 +1337,12 @@ class MasterClassicController(MasterController):
                             1: 'OUTPUT',
                             2: 'INPUT'}
             address = MasterClassicController._format_address(api_data['id'])
+            module_type = chr(api_data['id'][0])
             with self._module_log_lock:
                 self._module_log.append({'code': code_map.get(api_data['instr'], 'UNKNOWN').upper(),
                                          'module_nr': api_data['module_nr'],
                                          'category': category_map[api_data['io_type']],
-                                         'module_type': api_data['id'][0],
+                                         'module_type': module_type,
                                          'address': address})
             logger.info('Initialize/discovery - {0} module found: {1} ({2})'.format(
                 code_map.get(api_data['instr'], 'Unknown'),


### PR DESCRIPTION
Now that the master communicator uses bytearrays the api_data doesn't
contain regular ascii strings anymore, resulting in an integer.

    {u'category': u'OUTPUT', u'module_nr': 0, u'code': u'EXISTING', u'module_type': 79, u'address': u'079.046.051.061'}