### PR TITLE
ensure openmotics.conf can't corrupt

### DIFF
--- a/src/gateway/__init__.py
+++ b/src/gateway/__init__.py
@@ -14,4 +14,4 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """ Module containing the functionality provided by the gateway. """
 
-__version__ = '2.16.6'
+__version__ = '2.16.7'

--- a/src/update.py
+++ b/src/update.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 import sys
 import hashlib
 import traceback
+import shutil
 import subprocess
 
 from six.moves.configparser import ConfigParser
@@ -76,8 +77,11 @@ def update(version, md5_server):
         config = ConfigParser()
         config.read(get_config_file())
         config.set('OpenMotics', 'version', version)
-        with open(get_config_file(), 'wb') as configfile:
+        temp_file = get_config_file() + '.update'
+        with open(temp_file, 'wb') as configfile:
             config.write(configfile)
+        shutil.move(temp_file, get_config_file())
+        subprocess.check_call(['sync'])
 
         return extract_output + '\n' + update_output + '\n' + cleanup_output
 


### PR DESCRIPTION
With updates that require a reboot it's possible that recent file
changes are not fully flushed to disk yet. This can result in an empty
config file when it's updated in place.