### PR TITLE
check status in update test

### DIFF
--- a/testing/cicd/tests/conftest.py
+++ b/testing/cicd/tests/conftest.py
@@ -59,8 +59,9 @@ def software_update(toolbox_session):
             toolbox.dut.login()
             logger.debug('update output')
             output = toolbox.dut.get('/get_update_output')['output']
-            for log in output:
-                print(log)
+            logger.info(output)
+            assert 'exit 0' in output
+            assert 'DONE' in output
 
     logger.info('gateway {}'.format(toolbox.get_gateway_version()))
 


### PR DESCRIPTION
Also log the update output regardless of the status since firmware
updates currently don't affect the overall status.