### PR TITLE
fix shutdown behaviour of plugins

### DIFF
--- a/src/plugin_runtime/runtime.py
+++ b/src/plugin_runtime/runtime.py
@@ -229,6 +229,7 @@ class PluginRuntime(object):
         return data
 
     def _handle_stop(self):
+
         def delayed_stop():
             time.sleep(2)
             os._exit(0)
@@ -237,7 +238,6 @@ class PluginRuntime(object):
         stop_thread.daemon = True
         stop_thread.start()
 
-        self._reader.stop()
         self._stopped = True
 
     def _handle_input_status(self, data):

--- a/src/plugins/runner.py
+++ b/src/plugins/runner.py
@@ -112,7 +112,8 @@ class PluginRunner(object):
         self._writer = PluginIPCWriter(stream=self._proc.stdin)
         self._reader = PluginIPCReader(stream=self._proc.stdout,
                                        logger=lambda message, ex: self.logger('{0}: {1}'.format(message, ex)),
-                                       command_receiver=self._process_command)
+                                       command_receiver=self._process_command,
+                                       name=self.name)
         self._reader.start()
 
         start_out = self._do_command('start', timeout=180)

--- a/src/toolbox.py
+++ b/src/toolbox.py
@@ -82,14 +82,15 @@ class PluginIPCReader(object):
     It uses a stream of msgpack encoded dict values.
     """
 
-    def __init__(self, stream, logger, command_receiver=None):
-        # type: (IO[bytes], Callable[[str,Exception],None], Callable[[Dict[str,Any]],None]) -> None
+    def __init__(self, stream, logger, command_receiver=None, name=None):
+        # type: (IO[bytes], Callable[[str,Exception],None], Callable[[Dict[str,Any]],None],Optional[str]) -> None
         self._command_queue = Queue()
         self._unpacker = msgpack.Unpacker(stream, read_size=1, raw=False)  # type: msgpack.Unpacker[Dict[str,Any]]
         self._read_thread = None  # type: Optional[Thread]
         self._logger = logger
         self._running = False
         self._command_receiver = command_receiver
+        self._name = name
 
     def start(self):
         # type: () -> None
@@ -116,7 +117,7 @@ class PluginIPCReader(object):
                 else:
                     self._command_queue.put(command)
             except StopIteration as ex:
-                self._logger('PluginIPCReader stopped', ex)
+                self._logger('PluginIPCReader %s stopped' % self._name, ex)
                 self._running = False
             except Exception as ex:
                 self._logger('Unexpected read exception', ex)


### PR DESCRIPTION
Not stopping the reader makes sure the plugin has a chance to reply to
the stop command before terminating.

```
3.22s call     testing/unittests/plugins_tests/base_test.py::PluginControllerTest::test_plugin_metric_reference
2.28s call     testing/unittests/plugins_tests/base_test.py::PluginControllerTest::test_update_plugin
1.63s call     testing/unittests/plugins_tests/base_test.py::PluginControllerTest::test_get_special_methods
1.20s call     testing/unittests/plugins_tests/base_test.py::PluginControllerTest::test_get_shutter_decorators
1.19s call     testing/unittests/plugins_tests/base_test.py::PluginControllerTest::test_get_two_plugins
```