### PR TITLE
use a single filedescriptor for locking and reading

### DIFF
--- a/src/gateway/initialize.py
+++ b/src/gateway/initialize.py
@@ -75,14 +75,13 @@ def initialize(message_client_name):
 @contextmanager
 def lock_file(file):
     # type: (str) -> Any
-    with open(file, 'a') as wfd:
-        fcntl.flock(wfd, fcntl.LOCK_EX)
+    with open(file, 'a+') as fd:
+        fcntl.flock(fd, fcntl.LOCK_EX)
         try:
-            with open(file, 'r') as rfd:
-                yield rfd
+            yield fd
             os.unlink(file)
         except Exception:
-            fcntl.flock(wfd, fcntl.LOCK_UN)
+            fcntl.flock(fd, fcntl.LOCK_UN)
             raise
 
 


### PR DESCRIPTION
This avoids a race condition where the lock is removed before it's
openend for the second time.