### PR TITLE
reduce event broadcasting

### DIFF
--- a/src/gateway/base_controller.py
+++ b/src/gateway/base_controller.py
@@ -59,7 +59,7 @@ class BaseController(object):
         self._sync_running = False
 
         self._pubsub.subscribe_master_events(PubSub.MasterTopics.EEPROM, self._handle_master_event)
-        self._pubsub.subscribe_master_events(PubSub.MasterTopics.MASTER, self._handle_master_event)
+        self._pubsub.subscribe_master_events(PubSub.MasterTopics.MODULE, self._handle_master_event)
 
     def _handle_master_event(self, master_event):
         # type: (MasterEvent) -> None

--- a/src/gateway/hal/master_controller_classic.py
+++ b/src/gateway/hal/master_controller_classic.py
@@ -328,11 +328,8 @@ class MasterClassicController(MasterController):
             event_data = {'id': output_id, 'status': status}
             if dimmer is not None:
                 event_data['dimmer'] = dimmer
-            self._publish_event(MasterEvent(event_type=MasterEvent.Types.OUTPUT_STATUS, data=event_data))
-
-    def _publish_event(self, master_event):
-        # type: (MasterEvent) -> None
-        self._pubsub.publish_master_event(PubSub.MasterTopics.MASTER, master_event)
+            master_event = MasterEvent(event_type=MasterEvent.Types.OUTPUT_STATUS, data=event_data)
+            self._pubsub.publish_master_event(PubSub.MasterTopics.OUTPUT, master_event)
 
     def _invalidate_caches(self):
         # type: () -> None
@@ -562,7 +559,8 @@ class MasterClassicController(MasterController):
         event_data = {'id': input_id,
                       'status': status,
                       'location': {'room_id': Toolbox.denonify(input_configuration.room, 255)}}
-        self._publish_event(MasterEvent(event_type=MasterEvent.Types.INPUT_CHANGE, data=event_data))
+        master_event = MasterEvent(event_type=MasterEvent.Types.INPUT_CHANGE, data=event_data)
+        self._pubsub.publish_master_event(PubSub.MasterTopics.INPUT, master_event)
 
     def _is_output_locked(self, output_id):
         # TODO remove self._output_config cache, this belongs in the output controller.
@@ -635,7 +633,8 @@ class MasterClassicController(MasterController):
             event_data = {'id': shutter_id,
                           'status': new_state[i],
                           'location': {'room_id': self._shutter_config[shutter_id].room}}
-            self._publish_event(MasterEvent(event_type=MasterEvent.Types.SHUTTER_CHANGE, data=event_data))
+            master_event = MasterEvent(event_type=MasterEvent.Types.SHUTTER_CHANGE, data=event_data)
+            self._pubsub.publish_master_event(PubSub.MasterTopics.SHUTTER, master_event)
 
     def _interprete_output_states(self, module_id, output_states):
         states = []
@@ -1391,7 +1390,6 @@ class MasterClassicController(MasterController):
     @communication_enabled
     def module_discover_start(self, timeout):  # type: (int) -> None
         def _stop(): self.module_discover_stop()
-
         self._master_communicator.do_command(master_api.module_discover_start())
 
         if self._discover_mode_timer is not None:
@@ -1425,7 +1423,8 @@ class MasterClassicController(MasterController):
     def _broadcast_module_discovery(self):
         # type: () -> None
         self._eeprom_controller.invalidate_cache()
-        self._publish_event(MasterEvent(event_type=MasterEvent.Types.MODULE_DISCOVERY, data={}))
+        master_event = MasterEvent(event_type=MasterEvent.Types.MODULE_DISCOVERY, data={})
+        self._pubsub.publish_master_event(PubSub.MasterTopics.MODULE, master_event)
 
     # Error functions
 
@@ -1757,4 +1756,5 @@ class MasterClassicController(MasterController):
             if output_dto.lock_bit_id == bit_nr:
                 locked = value  # the bit is set, the output is locked
                 event_data = {'id': output_id, 'locked': locked}
-                self._publish_event(MasterEvent(event_type=MasterEvent.Types.OUTPUT_STATUS, data=event_data))
+                master_event = MasterEvent(event_type=MasterEvent.Types.OUTPUT_STATUS, data=event_data)
+                self._pubsub.publish_master_event(PubSub.MasterTopics.OUTPUT, master_event)

--- a/src/gateway/observer.py
+++ b/src/gateway/observer.py
@@ -46,7 +46,7 @@ class Observer(object):
         self._pubsub = pubsub  # type: PubSub
         self._message_client = message_client  # type: Optional[MessageClient]
 
-        self._pubsub.subscribe_master_events(PubSub.MasterTopics.MASTER, self._handle_master_event)
+        self._pubsub.subscribe_master_events(PubSub.MasterTopics.INPUT, self._handle_master_event)
 
     def _handle_master_event(self, master_event):
         # type: (MasterEvent) -> None

--- a/src/gateway/output_controller.py
+++ b/src/gateway/output_controller.py
@@ -54,6 +54,8 @@ class OutputController(BaseController):
         self._cache = OutputStateCache()
         self._sync_state_thread = None  # type: Optional[DaemonThread]
 
+        self._pubsub.subscribe_master_events(PubSub.MasterTopics.OUTPUT, self._handle_master_event)
+
     def start(self):
         # type: () -> None
         super(OutputController, self).start()

--- a/src/gateway/pubsub.py
+++ b/src/gateway/pubsub.py
@@ -28,7 +28,7 @@ if False:  # MYPY
     from gateway.events import GatewayEvent
     from gateway.hal.master_event import MasterEvent
     GATEWAY_TOPIC = Literal['config', 'state']
-    MASTER_TOPIC = Literal['eeprom', 'maintenance', 'master', 'power']
+    MASTER_TOPIC = Literal['eeprom', 'maintenance', 'module', 'power', 'output', 'input', 'shutter']
 
 logger = logging.getLogger('openmotics')
 
@@ -40,8 +40,11 @@ class PubSub(object):
     class MasterTopics(object):
         EEPROM = 'eeprom'  # type: MASTER_TOPIC
         MAINTENANCE = 'maintenance'  # type: MASTER_TOPIC
-        MASTER = 'master'  # type: MASTER_TOPIC
         POWER = 'power'  # type: MASTER_TOPIC
+        MODULE = 'module'  # type: MASTER_TOPIC
+        OUTPUT = 'output'  # type: MASTER_TOPIC
+        INPUT = 'input'  # type: MASTER_TOPIC
+        SHUTTER = 'shutter'  # type: MASTER_TOPIC
 
     class GatewayTopics(object):
         CONFIG = 'config'  # type: GATEWAY_TOPIC

--- a/src/gateway/shutter_controller.py
+++ b/src/gateway/shutter_controller.py
@@ -77,6 +77,8 @@ class ShutterController(BaseController):
         self._verbose = verbose
         self._config_lock = Lock()
 
+        self._pubsub.subscribe_master_events(PubSub.MasterTopics.SHUTTER, self._handle_master_event)
+
     def _log(self, message):  # type: (str) -> None
         if self._verbose:
             logger.info('ShutterController: {0}'.format(message))

--- a/testing/unittests/gateway_tests/hal/master_controller_classic_test.py
+++ b/testing/unittests/gateway_tests/hal/master_controller_classic_test.py
@@ -115,7 +115,7 @@ class MasterClassicControllerTest(unittest.TestCase):
             pubsub = get_pubsub()
             controller._register_version_depending_background_consumers()
             controller._input_config = {1: InputDTO(id=1)}  # TODO: cleanup
-            pubsub.subscribe_master_events(PubSub.MasterTopics.MASTER, subscriber.callback)
+            pubsub.subscribe_master_events(PubSub.MasterTopics.INPUT, subscriber.callback)
             new_consumer.assert_called()
             consumer_list[-2].deliver({'input': 1})
             pubsub._publish_all_events()
@@ -149,7 +149,7 @@ class MasterClassicControllerTest(unittest.TestCase):
 
         classic = get_classic_controller_dummy()
         pubsub = get_pubsub()
-        pubsub.subscribe_master_events(PubSub.MasterTopics.MASTER, _on_event)
+        pubsub.subscribe_master_events(PubSub.MasterTopics.OUTPUT, _on_event)
         classic._output_config = {0: OutputDTO(id=0),
                                   1: OutputDTO(id=1),
                                   2: OutputDTO(id=2, room=3)}
@@ -200,7 +200,7 @@ class MasterClassicControllerTest(unittest.TestCase):
             if master_event.type == MasterEvent.Types.OUTPUT_STATUS:
                 events.append(master_event.data)
 
-        pubsub.subscribe_master_events(PubSub.MasterTopics.MASTER, _on_event)
+        pubsub.subscribe_master_events(PubSub.MasterTopics.OUTPUT, _on_event)
         classic._validation_bits = ValidationBitStatus(on_validation_bit_change=classic._validation_bit_changed)
         classic._output_config = {0: OutputDTO(0, lock_bit_id=5)}
         pubsub._publish_all_events()
@@ -231,7 +231,7 @@ class MasterClassicControllerTest(unittest.TestCase):
                 assert len(synchronize.call_args_list) == 1
                 assert len(invalidate) == 0
 
-                pubsub.subscribe_master_events(PubSub.MasterTopics.MASTER, subscriber.callback)
+                pubsub.subscribe_master_events(PubSub.MasterTopics.MODULE, subscriber.callback)
                 controller.module_discover_stop()
                 pubsub._publish_all_events()
                 time.sleep(0.2)

--- a/testing/unittests/gateway_tests/hal/master_controller_core_test.py
+++ b/testing/unittests/gateway_tests/hal/master_controller_core_test.py
@@ -81,7 +81,7 @@ class MasterCoreControllerTest(unittest.TestCase):
         def _on_event(master_event):
             events.append(master_event)
 
-        self.pubsub.subscribe_master_events(PubSub.MasterTopics.MASTER, _on_event)
+        self.pubsub.subscribe_master_events(PubSub.MasterTopics.OUTPUT, _on_event)
 
         events = []
         self.controller._handle_event({'type': 0, 'device_nr': 0, 'action': 0, 'data': bytearray([255, 0, 0, 0])})
@@ -96,7 +96,7 @@ class MasterCoreControllerTest(unittest.TestCase):
         def _on_event(master_event):
             events.append(master_event)
 
-        self.pubsub.subscribe_master_events(PubSub.MasterTopics.MASTER, _on_event)
+        self.pubsub.subscribe_master_events(PubSub.MasterTopics.SHUTTER, _on_event)
 
         self.controller._output_states = {0: OutputStateDTO(id=0, status=False),
                                           10: OutputStateDTO(id=10, status=False),
@@ -111,32 +111,27 @@ class MasterCoreControllerTest(unittest.TestCase):
             self.controller._handle_event({'type': 0, 'device_nr': 10, 'action': 0, 'data': [None, 0, 0, 0]})
             self.controller._handle_event({'type': 0, 'device_nr': 11, 'action': 0, 'data': [None, 0, 0, 0]})
             self.pubsub._publish_all_events()
-            assert [MasterEvent('OUTPUT_STATUS', {'id': 10, 'status': False, 'dimmer': None, 'ctimer': 0}),
-                    MasterEvent('OUTPUT_STATUS', {'id': 11, 'status': False, 'dimmer': None, 'ctimer': 0})] == events
+            assert [] == events
 
             events = []
             self.controller._handle_event({'type': 0, 'device_nr': 10, 'action': 1, 'data': [None, 0, 0, 0]})
             self.pubsub._publish_all_events()
-            assert [MasterEvent('OUTPUT_STATUS', {'id': 10, 'status': True, 'dimmer': None, 'ctimer': 0}),
-                    MasterEvent('SHUTTER_CHANGE', {'id': 1, 'status': 'going_up', 'location': {'room_id': 255}})] == events
+            assert [MasterEvent('SHUTTER_CHANGE', {'id': 1, 'status': 'going_up', 'location': {'room_id': 255}})] == events
 
             events = []
             self.controller._handle_event({'type': 0, 'device_nr': 11, 'action': 1, 'data': [None, 0, 0, 0]})
             self.pubsub._publish_all_events()
-            assert [MasterEvent('OUTPUT_STATUS', {'id': 11, 'status': True, 'dimmer': None, 'ctimer': 0}),
-                    MasterEvent('SHUTTER_CHANGE', {'id': 1, 'status': 'stopped', 'location': {'room_id': 255}})] == events
+            assert [MasterEvent('SHUTTER_CHANGE', {'id': 1, 'status': 'stopped', 'location': {'room_id': 255}})] == events
 
             events = []
             self.controller._handle_event({'type': 0, 'device_nr': 10, 'action': 0, 'data': [None, 0, 0, 0]})
             self.pubsub._publish_all_events()
-            assert [MasterEvent('OUTPUT_STATUS', {'id': 10, 'status': False, 'dimmer': None, 'ctimer': 0}),
-                    MasterEvent('SHUTTER_CHANGE', {'id': 1, 'status': 'going_down', 'location': {'room_id': 255}})] == events
+            assert [MasterEvent('SHUTTER_CHANGE', {'id': 1, 'status': 'going_down', 'location': {'room_id': 255}})] == events
 
             events = []
             self.controller._handle_event({'type': 0, 'device_nr': 11, 'action': 0, 'data': [None, 0, 0, 0]})
             self.pubsub._publish_all_events()
-            assert [MasterEvent('OUTPUT_STATUS', {'id': 11, 'status': False, 'dimmer': None, 'ctimer': 0}),
-                    MasterEvent('SHUTTER_CHANGE', {'id': 1, 'status': 'stopped', 'location': {'room_id': 255}})] == events
+            assert [MasterEvent('SHUTTER_CHANGE', {'id': 1, 'status': 'stopped', 'location': {'room_id': 255}})] == events
 
     def test_master_shutter_refresh(self):
         events = []
@@ -144,7 +139,7 @@ class MasterCoreControllerTest(unittest.TestCase):
         def _on_event(master_event):
             events.append(master_event)
 
-        self.pubsub.subscribe_master_events(PubSub.MasterTopics.MASTER, _on_event)
+        self.pubsub.subscribe_master_events(PubSub.MasterTopics.SHUTTER, _on_event)
 
         output_status = [{'device_nr': 0, 'status': False, 'dimmer': 0},
                          {'device_nr': 1, 'status': False, 'dimmer': 0},
@@ -242,7 +237,7 @@ class MasterCoreControllerTest(unittest.TestCase):
         with mock.patch.object(gateway.hal.master_controller_core, 'BackgroundConsumer',
                                side_effect=new_consumer) as new_consumer:
             controller = MasterCoreController()
-        self.pubsub.subscribe_master_events(PubSub.MasterTopics.MASTER, subscriber.callback)
+        self.pubsub.subscribe_master_events(PubSub.MasterTopics.INPUT, subscriber.callback)
 
         new_consumer.assert_called()
         event_data = {'type': 1, 'action': 1, 'device_nr': 2,


### PR DESCRIPTION
Introduce topics separate for each controller so events on busy topics
like the classic master outputs are only dispatched to the corresponding
controller.