### PR TITLE
fix identity used in event_enabled cache

### DIFF
--- a/src/gateway/input_controller.py
+++ b/src/gateway/input_controller.py
@@ -80,5 +80,5 @@ class InputController(BaseController):
 
     @staticmethod
     def load_inputs_event_enabled():
-        return {input_['id']: input_['event_enabled']
+        return {input_['number']: input_['event_enabled']
                 for input_ in Input.select().dicts()}

--- a/testing/unittests/gateway_tests/events_test.py
+++ b/testing/unittests/gateway_tests/events_test.py
@@ -45,8 +45,8 @@ class EventsTest(unittest.TestCase):
         self.assertFalse(event_sender._batch_send_events())
 
         select_mock = Mock()
-        select_mock.dicts.return_value = [{'id': 1, 'event_enabled': True},
-                                          {'id': 2, 'event_enabled': False}]
+        select_mock.dicts.return_value = [{'number': 1, 'event_enabled': True},
+                                          {'number': 2, 'event_enabled': False}]
 
         with patch.object(Input, 'select', return_value=select_mock):
             with patch.object(Config, 'get_entry', return_value=True):

--- a/testing/unittests/gateway_tests/input_controller_test.py
+++ b/testing/unittests/gateway_tests/input_controller_test.py
@@ -71,8 +71,8 @@ class InputControllerTest(unittest.TestCase):
     def test_full_loaded_inputs(self):
         master_dtos = {1: InputDTO(id=1, name='one'),
                        2: InputDTO(id=2, name='two')}
-        orm_inputs = [Input(id=0, number=1, event_enabled=False),
-                      Input(id=1, number=2, event_enabled=True)]
+        orm_inputs = [Input(id=10, number=1, event_enabled=False),
+                      Input(id=11, number=2, event_enabled=True)]
         select_mock = mock.Mock()
         select_mock.join_from.return_value = orm_inputs
         with mock.patch.object(Input, 'select', return_value=select_mock), \


### PR DESCRIPTION
All master entities like inputs/outputs still use the number from the
master as identity everywhere.