### PR TITLE
move configuration when removing a plugin

### DIFF
--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -366,7 +366,7 @@ class PluginController(object):
         # Remove the plugin configuration
         conf_file = '{0}/pi_{1}.conf'.format(self._plugin_config_path, name)
         if os.path.exists(conf_file):
-            os.remove(conf_file)
+            os.rename(conf_file, '{}.bak'.format(conf_file))
 
         # Finally remove database entry.
         Plugin.delete().where(Plugin.name == name).execute()


### PR DESCRIPTION
Plugin configuration can contain important data, renaming ensures that
re-installing or accidentally removing a plugin is less dangerous since
the config can still be recovered.