### PR TITLE
Reduce amount of LED commands on Core(+)

### DIFF
--- a/src/gateway/hal/frontpanel_controller.py
+++ b/src/gateway/hal/frontpanel_controller.py
@@ -92,6 +92,7 @@ class FrontpanelController(object):
         self._power_communicator = power_communicator
         self._network_carrier = None
         self._network_activity = None
+        self._network_activity_scan_counter = 0
         self._network_bytes = 0
         self._check_network_activity_thread = None
         self._authorized_mode = False
@@ -158,30 +159,38 @@ class FrontpanelController(object):
             with open('/sys/class/net/{0}/carrier'.format(FrontpanelController.MAIN_INTERFACE), 'r') as fh_up:
                 line = fh_up.read()
             carrier = int(line) == 1
-            if self._network_carrier != carrier:
+            carrier_changed = self._network_carrier != carrier
+            if carrier_changed:
                 self._network_carrier = carrier
                 self._report_carrier(carrier)
 
-            with open('/proc/net/dev', 'r') as fh_stat:
-                for line in fh_stat.readlines():
-                    if FrontpanelController.MAIN_INTERFACE in line:
-                        received, transmitted = 0, 0
-                        parts = line.split()
-                        if len(parts) == 17:
-                            received = parts[1]
-                            transmitted = parts[9]
-                        elif len(parts) == 16:
-                            (_, received) = tuple(parts[0].split(':'))
-                            transmitted = parts[8]
-                        new_bytes = received + transmitted
-                        if self._network_bytes != new_bytes:
-                            self._network_bytes = new_bytes
-                            network_activity = True
-                        else:
-                            network_activity = False
-                        if self._network_activity != network_activity or network_activity:
-                            self._report_network_activity(network_activity)
-                        self._network_activity = network_activity
+            # Check network activity every second, or if the carrier changed
+            if self._network_activity_scan_counter >= 9 or carrier_changed:
+                self._network_activity_scan_counter = 0
+                network_activity = False
+                if self._network_carrier:  # There's no activity when there's no carrier
+                    with open('/proc/net/dev', 'r') as fh_stat:
+                        for line in fh_stat.readlines():
+                            if FrontpanelController.MAIN_INTERFACE not in line:
+                                continue
+                            received, transmitted = 0, 0
+                            parts = line.split()
+                            if len(parts) == 17:
+                                received = parts[1]
+                                transmitted = parts[9]
+                            elif len(parts) == 16:
+                                (_, received) = tuple(parts[0].split(':'))
+                                transmitted = parts[8]
+                            new_bytes = received + transmitted
+                            if self._network_bytes != new_bytes:
+                                self._network_bytes = new_bytes
+                                network_activity = True
+                            else:
+                                network_activity = False
+                if self._network_activity != network_activity:
+                    self._report_network_activity(network_activity)
+                self._network_activity = network_activity
+            self._network_activity_scan_counter += 1
         except Exception as exception:
             logger.error('Error while checking network activity: {0}'.format(exception))
 

--- a/src/gateway/hal/frontpanel_controller_classic.py
+++ b/src/gateway/hal/frontpanel_controller_classic.py
@@ -38,7 +38,6 @@ class FrontpanelClassicController(FrontpanelController):
     BOARD_TYPE = Hardware.get_board_type()
     ACTION_BUTTON_GPIO = 38 if BOARD_TYPE == Hardware.BoardType.BB else 26
     BUTTON = FrontpanelController.Buttons.ACTION
-    INDICATE_SEQUENCE = [True, False, False, False]
     AUTH_MODE_LEDS = [FrontpanelController.Leds.ALIVE,
                       FrontpanelController.Leds.CLOUD,
                       FrontpanelController.Leds.VPN,
@@ -61,6 +60,18 @@ class FrontpanelClassicController(FrontpanelController):
                           FrontpanelController.Leds.VPN: 16,
                           FrontpanelController.Leds.CLOUD: 4}
     I2C_DEVICE = '/dev/i2c-2' if BOARD_TYPE == Hardware.BoardType.BB else '/dev/i2c-1'
+    ALL_LEDS = [FrontpanelController.Leds.POWER,
+                FrontpanelController.Leds.STATUS_RED,
+                FrontpanelController.Leds.COMMUNICATION_1,
+                FrontpanelController.Leds.COMMUNICATION_2,
+                FrontpanelController.Leds.VPN,
+                FrontpanelController.Leds.ALIVE,
+                FrontpanelController.Leds.CLOUD]
+    BLINK_SEQUENCE = {FrontpanelController.LedStates.OFF: [],
+                      FrontpanelController.LedStates.BLINKING_25: [0],
+                      FrontpanelController.LedStates.BLINKING_50: [0, 1],
+                      FrontpanelController.LedStates.BLINKING_75: [0, 1, 2],
+                      FrontpanelController.LedStates.SOLID: [0, 1, 2, 3]}
 
     @Inject
     def __init__(self, leds_i2c_address=INJECTED):  # type: (int) -> None
@@ -69,12 +80,13 @@ class FrontpanelClassicController(FrontpanelController):
         self._button_states = {}  # type: Dict[str, bool]
         self._poll_button_thread = None
         self._write_leds_thread = None
-        self._enabled_leds = {}  # type: Dict[str, bool]
+        self._enabled_leds = {}  # type: Dict[str, str]
+        self._current_leds = {}  # type: Dict[str, bool]
         self._previous_leds = {}  # type: Dict[str, bool]
         self._last_i2c_led_code = None  # type: Optional[int]
         self._button_pressed_since = None  # type: Optional[float]
         self._button_released = False
-        self._indicate_pointer = 0
+        self._blink_counter = 0
 
     def _poll_button(self):
         # Check new state
@@ -104,7 +116,7 @@ class FrontpanelClassicController(FrontpanelController):
     def start(self):
         super(FrontpanelClassicController, self).start()
         # Enable power led
-        self._enabled_leds[FrontpanelController.Leds.POWER] = True
+        self._enabled_leds[FrontpanelController.Leds.POWER] = FrontpanelController.LedStates.SOLID
         # Start polling/writing threads
         self._poll_button_thread = DaemonThread(name='buttonpoller',
                                                 target=self._poll_button,
@@ -122,13 +134,10 @@ class FrontpanelClassicController(FrontpanelController):
         if self._write_leds_thread is not None:
             self._write_leds_thread.stop()
 
-    def _toggle_led(self, led):
-        currently_enabled = self._enabled_leds.get(led, False)
-        self._enabled_leds[led] = not currently_enabled
-
     def _report_carrier(self, carrier):
         # type: (bool) -> None
-        self._enabled_leds[FrontpanelController.Leds.STATUS_RED] = not carrier
+        state = FrontpanelController.LedStates.OFF if carrier else FrontpanelController.LedStates.SOLID
+        self._enabled_leds[FrontpanelController.Leds.STATUS_RED] = state
 
     def _report_connectivity(self, connectivity):
         # type: (bool) -> None
@@ -136,10 +145,8 @@ class FrontpanelClassicController(FrontpanelController):
 
     def _report_network_activity(self, activity):
         # type: (bool) -> None
-        if activity:
-            self._toggle_led(FrontpanelController.Leds.ALIVE)
-        else:
-            self._enabled_leds[FrontpanelController.Leds.ALIVE] = False
+        state = FrontpanelController.LedStates.BLINKING_50 if activity else FrontpanelController.LedStates.OFF
+        self._enabled_leds[FrontpanelController.Leds.ALIVE] = state
 
     def _report_serial_activity(self, serial_port, activity):
         # type: (str, Optional[bool]) -> None
@@ -147,32 +154,40 @@ class FrontpanelClassicController(FrontpanelController):
                FrontpanelController.SerialPorts.MASTER_API: FrontpanelController.Leds.COMMUNICATION_2}.get(serial_port)
         if led is None:
             return
-        if activity:
-            self._toggle_led(led)
-        else:
-            self._enabled_leds[led] = False
+        state = FrontpanelController.LedStates.BLINKING_50 if activity else FrontpanelController.LedStates.OFF
+        self._enabled_leds[led] = state
 
     def _report_cloud_reachable(self, reachable):
         # type: (bool) -> None
-        self._enabled_leds[FrontpanelController.Leds.CLOUD] = reachable
+        state = FrontpanelController.LedStates.SOLID if reachable else FrontpanelController.LedStates.OFF
+        self._enabled_leds[FrontpanelController.Leds.CLOUD] = state
 
     def _report_vpn_open(self, vpn_open):
         # type: (bool) -> None
-        self._enabled_leds[FrontpanelController.Leds.VPN] = vpn_open
+        state = FrontpanelController.LedStates.SOLID if vpn_open else FrontpanelController.LedStates.OFF
+        self._enabled_leds[FrontpanelController.Leds.VPN] = state
 
     def _write_leds(self):
         # Override for indicate
         if self._indicate:
-            self._enabled_leds[FrontpanelController.Leds.STATUS_RED] = FrontpanelClassicController.INDICATE_SEQUENCE[self._indicate_pointer]
-            self._indicate_pointer = self._indicate_pointer + 1
-            if self._indicate_pointer >= len(FrontpanelClassicController.INDICATE_SEQUENCE):
-                self._indicate_pointer = 0
+            self._enabled_leds[FrontpanelController.Leds.STATUS_RED] = FrontpanelController.LedStates.BLINKING_25
+
+        # Map blinking states
+        for led in FrontpanelClassicController.ALL_LEDS:
+            requested_state = self._enabled_leds.get(led, FrontpanelController.LedStates.OFF)
+            if requested_state == FrontpanelController.LedStates.OFF:
+                self._current_leds[led] = False
+            else:
+                self._current_leds[led] = self._blink_counter in FrontpanelClassicController.BLINK_SEQUENCE[requested_state]
+        self._blink_counter += 1
+        if self._blink_counter >= 4:
+            self._blink_counter = 0
 
         # Drive I2C leds
         try:
             code = 0x0
             for led in FrontpanelClassicController.I2C_LED_CONFIG:
-                if self._enabled_leds.get(led, False) is True:
+                if self._current_leds.get(led, False) is True:
                     code |= FrontpanelClassicController.I2C_LED_CONFIG[led]
             if self._authorized_mode:
                 # Light all leds in authorized mode
@@ -192,7 +207,7 @@ class FrontpanelClassicController(FrontpanelController):
         # Drive GPIO leds
         try:
             for led in FrontpanelClassicController.GPIO_LED_CONFIG:
-                on = self._enabled_leds.get(led, False)
+                on = self._current_leds.get(led, False)
                 if self._previous_leds.get(led) != on:
                     self._previous_leds[led] = on
                     try:

--- a/src/gateway/hal/frontpanel_controller_core.py
+++ b/src/gateway/hal/frontpanel_controller_core.py
@@ -259,8 +259,7 @@ class FrontpanelCoreController(FrontpanelController):
             self._master_communicator.do_basic_action(BasicAction(action_type=210,
                                                                   action=action,
                                                                   device_nr=1 if on else 0,
-                                                                  extra_parameter=extra_parameter),
-                                                      log=False)
+                                                                  extra_parameter=extra_parameter))
             self._led_drive_states[led] = on, mode
 
 

--- a/src/master/core/core_communicator.py
+++ b/src/master/core/core_communicator.py
@@ -206,11 +206,10 @@ class CoreCommunicator(object):
             consumers.remove(consumer)
         self.discard_cid(consumer.cid)
 
-    def do_basic_action(self, basic_action, timeout=2, log=True):
-        # type: (BasicAction, Optional[int], bool) -> Optional[Dict[str, Any]]
+    def do_basic_action(self, basic_action, timeout=2):
+        # type: (BasicAction, Optional[int]) -> Optional[Dict[str, Any]]
         """ Sends a basic action to the Core with the given action type and action number """
-        if log:
-            logger.info('BA: Executed {0}'.format(basic_action))
+        logger.info('BA: Executed {0}'.format(basic_action))
         return self.do_command(
             CoreAPI.basic_action(),
             {'type': basic_action.action_type,

--- a/testing/unittests/gateway_tests/hal/frontpanel_controller_classic_test.py
+++ b/testing/unittests/gateway_tests/hal/frontpanel_controller_classic_test.py
@@ -31,46 +31,58 @@ class FrontpanelControllerClassicTest(unittest.TestCase):
 
     def test_serial_activity(self):
         controller = FrontpanelControllerClassicTest._get_controller()
-        for activity, led_state in [(False, False),
-                                    (True, True),
-                                    (True, False),
-                                    (True, True),
-                                    (False, False),
-                                    (False, False)]:
+        for activity, led_state in [(False, FrontpanelController.LedStates.OFF),
+                                    (True, FrontpanelController.LedStates.BLINKING_50),
+                                    (True, FrontpanelController.LedStates.BLINKING_50),
+                                    (False, FrontpanelController.LedStates.OFF),
+                                    (False, FrontpanelController.LedStates.OFF)]:
             controller._report_serial_activity(FrontpanelController.SerialPorts.MASTER_API, activity)
             self.assertEqual(led_state, controller._enabled_leds[FrontpanelController.Leds.COMMUNICATION_2])
 
     def test_report_carrier(self):
         controller = FrontpanelControllerClassicTest._get_controller()
         controller._report_carrier(False)
-        self.assertTrue(controller._enabled_leds[FrontpanelController.Leds.STATUS_RED])
+        self.assertEqual(FrontpanelController.LedStates.SOLID, controller._enabled_leds[FrontpanelController.Leds.STATUS_RED])
         controller._report_carrier(True)
-        self.assertFalse(controller._enabled_leds[FrontpanelController.Leds.STATUS_RED])
+        self.assertEqual(FrontpanelController.LedStates.OFF, controller._enabled_leds[FrontpanelController.Leds.STATUS_RED])
 
     def test_report_network_activity(self):
         controller = FrontpanelControllerClassicTest._get_controller()
-        for activity, led_state in [(False, False),
-                                    (True, True),
-                                    (True, False),
-                                    (True, True),
-                                    (False, False),
-                                    (False, False)]:
+        for activity, led_state in [(False, FrontpanelController.LedStates.OFF),
+                                    (True, FrontpanelController.LedStates.BLINKING_50),
+                                    (True, FrontpanelController.LedStates.BLINKING_50),
+                                    (False, FrontpanelController.LedStates.OFF),
+                                    (False, FrontpanelController.LedStates.OFF)]:
             controller._report_network_activity(activity)
             self.assertEqual(led_state, controller._enabled_leds[FrontpanelController.Leds.ALIVE])
 
     def test_report_cloud_reachable(self):
         controller = FrontpanelControllerClassicTest._get_controller()
         controller._report_cloud_reachable(False)
-        self.assertFalse(controller._enabled_leds[FrontpanelController.Leds.CLOUD])
+        self.assertEqual(FrontpanelController.LedStates.OFF, controller._enabled_leds[FrontpanelController.Leds.CLOUD])
         controller._report_cloud_reachable(True)
-        self.assertTrue(controller._enabled_leds[FrontpanelController.Leds.CLOUD])
+        self.assertEqual(FrontpanelController.LedStates.SOLID, controller._enabled_leds[FrontpanelController.Leds.CLOUD])
 
     def test_report_vpn_open(self):
         controller = FrontpanelControllerClassicTest._get_controller()
         controller._report_vpn_open(False)
-        self.assertFalse(controller._enabled_leds[FrontpanelController.Leds.VPN])
+        self.assertEqual(FrontpanelController.LedStates.OFF, controller._enabled_leds[FrontpanelController.Leds.VPN])
         controller._report_vpn_open(True)
-        self.assertTrue(controller._enabled_leds[FrontpanelController.Leds.VPN])
+        self.assertEqual(FrontpanelController.LedStates.SOLID, controller._enabled_leds[FrontpanelController.Leds.VPN])
+
+    def test_mapping(self):
+        controller = FrontpanelControllerClassicTest._get_controller()
+        led = FrontpanelController.Leds.CLOUD
+        for state, sequence in {FrontpanelController.LedStates.OFF: [False, False, False, False, False, False, False, False],
+                                FrontpanelController.LedStates.SOLID: [True, True, True, True, True, True, True, True],
+                                FrontpanelController.LedStates.BLINKING_25: [True, False, False, False, True, False, False, False],
+                                FrontpanelController.LedStates.BLINKING_50: [True, True, False, False, True, True, False, False],
+                                FrontpanelController.LedStates.BLINKING_75: [True, True, True, False, True, True, True, False]}.items():
+            controller._enabled_leds[led] = state
+            recorded_sequence = []
+            for i in range(8):
+                recorded_sequence.append(controller._map_states().get(led))
+            self.assertEqual(sequence, recorded_sequence)
 
     @staticmethod
     @Scope


### PR DESCRIPTION
The main monitor that checked for network activity always reported e.g. the network activity as it was this report that drove the blinking. However, the interval for checking network activity was too short causing a massive amount of BAs executed towards the core to start blinking, stop blinking, start blinking, ... The classic controller now executes the blinking itself, so the report can only happen on state change. This allows the network activity check interval to be reduced, reducing the change between blinking and not blinking.