### PR TITLE
Do not import six top level

### DIFF
--- a/src/platform_utils.py
+++ b/src/platform_utils.py
@@ -22,7 +22,6 @@ import subprocess
 import sys
 import constants
 
-from six.moves.configparser import ConfigParser
 if False:  # MYPY
     from typing import Union, Dict
 


### PR DESCRIPTION
Do not import six top level. This breaks angstrom.