### PR TITLE
increase timeout for eeprom activate

### DIFF
--- a/src/gateway/hal/master_controller_classic.py
+++ b/src/gateway/hal/master_controller_classic.py
@@ -288,7 +288,8 @@ class MasterClassicController(MasterController):
             write = True
 
         if write:
-            self._master_communicator.do_command(master_api.activate_eeprom(), {'eep': 0})
+            self._master_communicator.do_command(master_api.activate_eeprom(), {'eep': 0},
+                                                 timeout=5)
         self.set_status_leds(True)
 
     def _handle_maintenance_event(self, master_event):
@@ -1329,7 +1330,8 @@ class MasterClassicController(MasterController):
                         {'bank': bank, 'address': addr, 'data': new}
                     )
 
-        self._master_communicator.do_command(master_api.activate_eeprom(), {'eep': 0})
+        self._master_communicator.do_command(master_api.activate_eeprom(), {'eep': 0},
+                                             timeout=5)
         ret.append('Activated eeprom')
         self._eeprom_controller.invalidate_cache()
 

--- a/src/master/classic/eeprom_controller.py
+++ b/src/master/classic/eeprom_controller.py
@@ -157,7 +157,7 @@ class EepromFile(object):
         and adjust the current settings.
         """
         logger.info('EEPROM - Activate')
-        self._master_communicator.do_command(activate_eeprom(), {'eep': 0})
+        self._master_communicator.do_command(activate_eeprom(), {'eep': 0}, timeout=5)
         master_event = MasterEvent(MasterEvent.Types.EEPROM_CHANGE, {})
         self._pubsub.publish_master_event(PubSub.MasterTopics.EEPROM, master_event)
 

--- a/testing/unittests/master_tests/eeprom_controller_test.py
+++ b/testing/unittests/master_tests/eeprom_controller_test.py
@@ -472,7 +472,7 @@ class MasterCommunicator(object):
         self.__list_function = list_function
         self.__write_function = write_function
 
-    def do_command(self, cmd, data):
+    def do_command(self, cmd, data, timeout=None):
         """ Execute a command on the master dummy. """
         if cmd == master_api.eeprom_list():
             return self.__list_function(data)


### PR DESCRIPTION
On some systems this can take longer than the default timeout of 2s for
master commands, resulting in lots of failing calls.