### PR TITLE
handle partial module discovery for basic cases

### DIFF
--- a/testing/cicd/tests/mode_test.py
+++ b/testing/cicd/tests/mode_test.py
@@ -134,6 +134,7 @@ def factory_reset(request, toolbox):
 def test_factory_reset(toolbox, authorized_mode, factory_reset):
     data = toolbox.factory_reset()
     assert data['factory_reset'] == 'pending'
+    logger.info('factory reset pending...')
     time.sleep(60)
     toolbox.health_check(timeout=300)
 


### PR DESCRIPTION
Before initialize could fail to discover the output module if it
was already discovered when some of the other modules are missing.

    Did not discover required modules: O=1. Raw log: []