### PR TITLE
DTOs keep track of loaded fields

### DIFF
--- a/src/gateway/dto/base.py
+++ b/src/gateway/dto/base.py
@@ -19,9 +19,12 @@ Base DTO
 from functools import wraps
 from toolbox import Toolbox
 
+if False:  # MYPY
+    from typing import Set
+
 
 class BaseDTO(object):
-    _loaded_fields = set()
+    _loaded_fields = set()  # type: Set[str]
     _init_done = False
 
     def __str__(self):

--- a/src/gateway/dto/output.py
+++ b/src/gateway/dto/output.py
@@ -16,7 +16,7 @@
 """
 Output DTO
 """
-from gateway.dto.base import BaseDTO
+from gateway.dto.base import BaseDTO, capture_fields
 from gateway.dto.feedback_led import FeedbackLedDTO
 
 if False:  # MYPY
@@ -24,6 +24,7 @@ if False:  # MYPY
 
 
 class OutputDTO(BaseDTO):
+    @capture_fields
     def __init__(self, id, name='', module_type='O', timer=None, floor=None, output_type=None,
                  can_led_1=None,  # type: Optional[FeedbackLedDTO]
                  can_led_2=None,  # type: Optional[FeedbackLedDTO]
@@ -66,6 +67,7 @@ class OutputDTO(BaseDTO):
 
 
 class OutputStateDTO(BaseDTO):
+    @capture_fields
     def __init__(self, id, status=False, ctimer=0, dimmer=0, locked=False):
         # type: (int, bool, int, int, bool) -> None
         self.id = id  # type: int


### PR DESCRIPTION
```
>>> from platform_utils import System
>>> System.import_libs()
>>> from gateway.dto import OutputStateDTO, OutputDTO
>>> a = OutputStateDTO(5, locked=True)
>>> a
<OutputStateDTO {'locked': True, 'id': 5}>
>>> a = OutputStateDTO(5, True)
>>> a
<OutputStateDTO {'status': True, 'id': 5}>
>>> a.locked = False
>>> a
<OutputStateDTO {'status': True, 'locked': False, 'id': 5}>
>>> a.locked = True
>>> a.dimmer
0
>>> a
<OutputStateDTO {'status': True, 'locked': True, 'id': 5}>
>>> a.loaded_fields
['status', 'locked', 'id']
>>>
```