### PR TITLE
Nonify 255 for all lights off

### DIFF
--- a/src/gateway/webservice.py
+++ b/src/gateway/webservice.py
@@ -62,6 +62,7 @@ from ioc import INJECTED, Inject, Injectable, Singleton
 from platform_utils import Hardware, Platform, System
 from power.power_communicator import InAddressModeException
 from serial_utils import CommunicationTimedOutException
+from toolbox import Toolbox
 
 if False:  # MYPY
     from typing import Dict, Optional, Any, List, Literal
@@ -695,12 +696,14 @@ class WebInterface(object):
     @openmotics_api(auth=True, check=types(floor=int))
     def set_all_lights_floor_off(self, floor):
         """ Turn all lights on a given floor off. """
+        floor = Toolbox.nonify(floor, 255)
         self._output_controller.set_all_lights(action='OFF', floor_id=floor)
         return {}
 
     @openmotics_api(auth=True, check=types(floor=int))
     def set_all_lights_floor_on(self, floor):
         """ Turn all lights on a given floor on. """
+        floor = Toolbox.nonify(floor, 255)
         self._output_controller.set_all_lights(action='ON', floor_id=floor)
         return {}
 

--- a/testing/unittests/gateway_tests/webservice_test.py
+++ b/testing/unittests/gateway_tests/webservice_test.py
@@ -151,3 +151,22 @@ class WebInterfaceTest(unittest.TestCase):
                 'timer': None
             }, json.loads(response)['status'])
             set_status.assert_called()
+
+    def test_set_all_lights_off(self):
+        with mock.patch.object(self.output_controller, 'set_all_lights',
+                               return_value={}) as set_status:
+            self.web.set_all_lights_off()
+            set_status.assert_called_with(action='OFF')
+
+            floor_expectations = [(255, None), (2, 2), (0, 0)]
+            for expectation in floor_expectations:
+                self.web.set_all_lights_floor_off(floor=expectation[0])
+                set_status.assert_called_with(action='OFF', floor_id=expectation[1])
+
+    def test_set_all_lights_on(self):
+        expectations = [(255, None), (2, 2), (0, 0)]
+        with mock.patch.object(self.output_controller, 'set_all_lights',
+                               return_value={}) as set_status:
+            for expectation in expectations:
+                self.web.set_all_lights_floor_on(floor=expectation[0])
+                set_status.assert_called_with(action='ON', floor_id=expectation[1])


### PR DESCRIPTION
```
2021-04-13 10:41:04,077 - openmotics - ERROR - Unexpected error during API call set_all_lights_off
Traceback (most recent call last):
  File “/opt/openmotics/python/gateway/webservice.py”, line 239, in _openmotics_api
    return_data = f(*args, **kwargs)
  File “/opt/openmotics/python/gateway/webservice.py”, line 692, in set_all_lights_off
    self._output_controller.set_all_lights(action=‘OFF’)
  File “/opt/openmotics/python/gateway/output_controller.py”, line 170, in set_all_lights
    self._master_controller.set_all_lights(action=action)
  File “/opt/openmotics/python/gateway/hal/master_controller_classic.py”, line 76, in wrapper
    return f(instance, *args, **kwargs)
  File “/opt/openmotics/python/gateway/hal/master_controller_classic.py”, line 1598, in set_all_lights
    self.do_basic_action(master_api.BA_LIGHTS_OFF_FLOOR, floor_id_byte)
  File “/opt/openmotics/python/gateway/hal/master_controller_classic.py”, line 76, in wrapper
    return f(instance, *args, **kwargs)
  File “/opt/openmotics/python/gateway/hal/master_controller_classic.py”, line 1485, in do_basic_action
    raise ValueError(‘action_number not in [0, 254]: %d’ % action_number)
ValueError: action_number not in [0, 254]: 255
```