### PR TITLE
Can FX call - see comment for logs

### DIFF
--- a/src/gateway/gateway_api.py
+++ b/src/gateway/gateway_api.py
@@ -236,6 +236,10 @@ class GatewayApi(object):
             values += [None] * (32 - len(values))
         return values
 
+    # For testing purposes - to avoid having to run the entire factory-reset test
+    def can_reset(self):
+        self.__master_controller.can_reset()
+
     def set_virtual_sensor(self, sensor_id, temperature, humidity, brightness):
         # TODO: work with sensor controller
         # TODO: add other sensors too (e.g. from database <-- plugins)

--- a/src/gateway/gateway_api.py
+++ b/src/gateway/gateway_api.py
@@ -400,7 +400,7 @@ class GatewayApi(object):
     def factory_reset(self, can=True):
         # type: (bool) -> Dict[str,Any]
         try:
-            subprocess.check_output(['python2', 'openmotics_cli.py', 'operator', 'factory-reset', 'can'])
+            subprocess.check_output(['python2', 'openmotics_cli.py', 'operator', 'factory-reset', '--can'])
         except subprocess.CalledProcessError as exc:
             return {'success': False, 'factory_reset': exc.output.strip()}
 

--- a/src/gateway/gateway_api.py
+++ b/src/gateway/gateway_api.py
@@ -397,8 +397,8 @@ class GatewayApi(object):
             # Restart the Cherrypy server after 1 second. Lets the current request terminate.
             threading.Timer(1, lambda: os._exit(0)).start()
 
-    def factory_reset(self, Can=False):
-        # type: () -> Dict[str,Any]
+    def factory_reset(self, can=True):
+        # type: (bool) -> Dict[str,Any]
         try:
             subprocess.check_output(['python2', 'openmotics_cli.py', 'operator', 'factory-reset'])
         except subprocess.CalledProcessError as exc:
@@ -410,7 +410,7 @@ class GatewayApi(object):
             System.restart_service('openmotics')
 
         threading.Timer(2, _restart).start()
-        if Can:
+        if can:
             return {'factory_reset_full': 'pending'}
         return {'factory_reset': 'pending'}
 

--- a/src/gateway/gateway_api.py
+++ b/src/gateway/gateway_api.py
@@ -400,7 +400,7 @@ class GatewayApi(object):
     def factory_reset(self, can=True):
         # type: (bool) -> Dict[str,Any]
         try:
-            subprocess.check_output(['python2', 'openmotics_cli.py', 'operator', 'factory-reset'])
+            subprocess.check_output(['python2', 'openmotics_cli.py', 'operator', 'factory-reset', 'can'])
         except subprocess.CalledProcessError as exc:
             return {'success': False, 'factory_reset': exc.output.strip()}
 

--- a/src/gateway/gateway_api.py
+++ b/src/gateway/gateway_api.py
@@ -236,10 +236,6 @@ class GatewayApi(object):
             values += [None] * (32 - len(values))
         return values
 
-    # For testing purposes - to avoid having to run the entire factory-reset test
-    def can_control_factory_reset(self):
-        self.__master_controller.can_control_factory_reset()
-
     def set_virtual_sensor(self, sensor_id, temperature, humidity, brightness):
         # TODO: work with sensor controller
         # TODO: add other sensors too (e.g. from database <-- plugins)
@@ -401,7 +397,7 @@ class GatewayApi(object):
             # Restart the Cherrypy server after 1 second. Lets the current request terminate.
             threading.Timer(1, lambda: os._exit(0)).start()
 
-    def factory_reset(self):
+    def factory_reset(self, Can=False):
         # type: () -> Dict[str,Any]
         try:
             subprocess.check_output(['python2', 'openmotics_cli.py', 'operator', 'factory-reset'])
@@ -414,6 +410,8 @@ class GatewayApi(object):
             System.restart_service('openmotics')
 
         threading.Timer(2, _restart).start()
+        if Can:
+            return {'factory_reset_full': 'pending'}
         return {'factory_reset': 'pending'}
 
     def get_master_backup(self):

--- a/src/gateway/gateway_api.py
+++ b/src/gateway/gateway_api.py
@@ -237,8 +237,8 @@ class GatewayApi(object):
         return values
 
     # For testing purposes - to avoid having to run the entire factory-reset test
-    def can_reset(self):
-        self.__master_controller.can_reset()
+    def can_control_factory_reset(self):
+        self.__master_controller.can_control_factory_reset()
 
     def set_virtual_sensor(self, sensor_id, temperature, humidity, brightness):
         # TODO: work with sensor controller

--- a/src/gateway/gateway_api.py
+++ b/src/gateway/gateway_api.py
@@ -400,7 +400,10 @@ class GatewayApi(object):
     def factory_reset(self, can=True):
         # type: (bool) -> Dict[str,Any]
         try:
-            subprocess.check_output(['python2', 'openmotics_cli.py', 'operator', 'factory-reset', '--can'])
+            argv = ['python2', 'openmotics_cli.py', 'operator', 'factory-reset']
+            if can:
+                argv.append('--can')
+            subprocess.check_output(argv)
         except subprocess.CalledProcessError as exc:
             return {'success': False, 'factory_reset': exc.output.strip()}
 

--- a/src/gateway/hal/master_controller.py
+++ b/src/gateway/hal/master_controller.py
@@ -417,7 +417,8 @@ class MasterController(object):
     def restore(self, data):
         raise NotImplementedError()
 
-    def factory_reset(self):
+    def factory_reset(self, can):
+        # type: (bool) -> None
         raise NotImplementedError()
 
     def sync_time(self):

--- a/src/gateway/hal/master_controller_classic.py
+++ b/src/gateway/hal/master_controller_classic.py
@@ -1164,12 +1164,13 @@ class MasterClassicController(MasterController):
                 time.sleep(2)  # Doing heavy reads on eeprom can exhaust the master. Give it a bit room to breathe.
         return ''.join(chr(c) for c in output)
 
-    def factory_reset(self):
+    def factory_reset(self, can=False):
         # type: () -> None
         # Wipe CC EEPROM
         # https://wiki.openmotics.com/index.php/API_Reference_Guide#FX_-.3E_Erase_external_Eeprom_slave_modules_and_perform_factory_reset
         # Erasing CAN EEPROM first because the master needs to have the module information
-        self.can_control_factory_reset()
+        if can:
+            self.can_control_factory_reset()
         # Wipe master EEPROM
         data = chr(255) * (256 * 256)
         self.restore(data)

--- a/src/gateway/hal/master_controller_classic.py
+++ b/src/gateway/hal/master_controller_classic.py
@@ -1166,31 +1166,15 @@ class MasterClassicController(MasterController):
 
     def factory_reset(self):
         # type: () -> None
-        # Wipe CAN EEPROM
+        # Wipe CC EEPROM
         # https://wiki.openmotics.com/index.php/API_Reference_Guide#FX_-.3E_Erase_external_Eeprom_slave_modules_and_perform_factory_reset
         # Erasing CAN EEPROM first because the master needs to have the module information
-        mods = self._master_communicator.do_command(master_api.number_of_io_modules())
-        for i in range(mods['in']):
-            is_can = self._eeprom_controller.read_address(EepromAddress(2 + i, 252, 1)).bytes == bytearray(b'C')
-            if is_can:
-                module_address = self._eeprom_controller.read_address(EepromAddress(2 + i, 0, 4))
-                module_type_letter = chr(module_address.bytes[0]).lower()
-                is_virtual = chr(module_address.bytes[0]).islower()
-                formatted_address = MasterClassicController._format_address(module_address.bytes)
-                if not is_virtual and module_type_letter == 'c':
-                    try:
-                        logging.info("Resetting CAN EEPROM, adress: {0} ".format(formatted_address))
-                        self._master_communicator.do_command(master_api.erase_can_eeprom(),
-                                                             {'addr': module_address.bytes, 'instr': 0},
-                                                             extended_crc=True, timeout=5)
-                    except CommunicationTimedOutException:
-                        logger.error('Got communication timeout during FX call')
-
+        self.can_control_factory_reset()
         # Wipe master EEPROM
         data = chr(255) * (256 * 256)
         self.restore(data)
 
-    def can_reset(self):
+    def can_control_factory_reset(self):
         mods = self._master_communicator.do_command(master_api.number_of_io_modules())
         for i in range(mods['in']):
             is_can = self._eeprom_controller.read_address(EepromAddress(2 + i, 252, 1)).bytes == bytearray(b'C')

--- a/src/gateway/hal/master_controller_classic.py
+++ b/src/gateway/hal/master_controller_classic.py
@@ -1165,7 +1165,7 @@ class MasterClassicController(MasterController):
         return ''.join(chr(c) for c in output)
 
     def factory_reset(self, can=False):
-        # type: () -> None
+        # type: (bool) -> None
         # Wipe CC EEPROM
         # https://wiki.openmotics.com/index.php/API_Reference_Guide#FX_-.3E_Erase_external_Eeprom_slave_modules_and_perform_factory_reset
         # Erasing CAN EEPROM first because the master needs to have the module information

--- a/src/gateway/initialize.py
+++ b/src/gateway/initialize.py
@@ -76,6 +76,10 @@ def initialize(message_client_name):
             logger.info('Running factory reset...')
             factory_reset()
             logger.info('Running factory reset, done')
+        elif content == 'factory_reset_full':
+            logger.info('Running full factory reset [also wiping CC EEPROM]...')
+            factory_reset(Can=True)
+            logger.info('Running full factory reset, done')
         else:
             logger.warning('unknown initialization {}'.format(content))
 
@@ -104,7 +108,7 @@ def apply_migrations():
 
 
 @Inject
-def factory_reset(master_controller=INJECTED):
+def factory_reset(master_controller=INJECTED, Can=False):
     # type: (MasterController) -> None
     import glob
     import shutil
@@ -115,7 +119,7 @@ def factory_reset(master_controller=INJECTED):
 
     logger.info('Wiping master eeprom...')
     master_controller.start()
-    master_controller.factory_reset()
+    master_controller.factory_reset(Can=Can)
     master_controller.stop()
 
     logger.info('Removing databases...')

--- a/src/gateway/initialize.py
+++ b/src/gateway/initialize.py
@@ -78,7 +78,7 @@ def initialize(message_client_name):
             logger.info('Running factory reset, done')
         elif content == 'factory_reset_full':
             logger.info('Running full factory reset [also wiping CC EEPROM]...')
-            factory_reset(Can=True)
+            factory_reset(can=True)
             logger.info('Running full factory reset, done')
         else:
             logger.warning('unknown initialization {}'.format(content))
@@ -108,8 +108,8 @@ def apply_migrations():
 
 
 @Inject
-def factory_reset(master_controller=INJECTED, Can=False):
-    # type: (MasterController) -> None
+def factory_reset(master_controller=INJECTED, can=True):
+    # type: (MasterController, bool) -> None
     import glob
     import shutil
 
@@ -119,7 +119,7 @@ def factory_reset(master_controller=INJECTED, Can=False):
 
     logger.info('Wiping master eeprom...')
     master_controller.start()
-    master_controller.factory_reset(Can=Can)
+    master_controller.factory_reset(can=can)
     master_controller.stop()
 
     logger.info('Removing databases...')

--- a/src/gateway/webservice.py
+++ b/src/gateway/webservice.py
@@ -597,11 +597,6 @@ class WebInterface(object):
         return {'old_module': ModuleSerializer.serialize(old_module, fields=None),
                 'new_module': ModuleSerializer.serialize(new_module, fields=None)}
 
-    # For testing purposes - to avoid having to run the entire factory-reset test
-    @openmotics_api(check=types(confirm=bool), auth=True, plugin_exposed=False)
-    def can_control_factory_reset(self):
-        self._gateway_api.can_control_factory_reset()
-        return {}
 
     @openmotics_api(auth=True)
     def get_features(self):
@@ -2382,7 +2377,7 @@ class WebInterface(object):
         return {'definitions': definitions}
 
     @openmotics_api(check=types(confirm=bool), auth=True, plugin_exposed=False)
-    def factory_reset(self, username, password, confirm=False):
+    def factory_reset(self, username, password, confirm=False, Can=False):
         user_dto = UserDTO(username=username)
         user_dto.set_password(password)
         success, _ = self._user_controller.login(user_dto)
@@ -2390,7 +2385,7 @@ class WebInterface(object):
             raise cherrypy.HTTPError(401, 'invalid_credentials')
         if not confirm:
             raise cherrypy.HTTPError(401, 'not_confirmed')
-        return self._gateway_api.factory_reset()
+        return self._gateway_api.factory_reset(Can=Can)
 
     @openmotics_api(auth=False)
     def health_check(self):

--- a/src/gateway/webservice.py
+++ b/src/gateway/webservice.py
@@ -597,6 +597,12 @@ class WebInterface(object):
         return {'old_module': ModuleSerializer.serialize(old_module, fields=None),
                 'new_module': ModuleSerializer.serialize(new_module, fields=None)}
 
+    # For testing purposes - to avoid having to run the entire factory-reset test
+    @openmotics_api(auth=True)
+    def can_reset(self):
+        self._gateway_api.can_reset()
+        return {}
+
     @openmotics_api(auth=True)
     def get_features(self):
         """

--- a/src/gateway/webservice.py
+++ b/src/gateway/webservice.py
@@ -598,9 +598,9 @@ class WebInterface(object):
                 'new_module': ModuleSerializer.serialize(new_module, fields=None)}
 
     # For testing purposes - to avoid having to run the entire factory-reset test
-    @openmotics_api(auth=True)
-    def can_reset(self):
-        self._gateway_api.can_reset()
+    @openmotics_api(check=types(confirm=bool), auth=True, plugin_exposed=False)
+    def can_control_factory_reset(self):
+        self._gateway_api.can_control_factory_reset()
         return {}
 
     @openmotics_api(auth=True)

--- a/src/gateway/webservice.py
+++ b/src/gateway/webservice.py
@@ -2377,7 +2377,7 @@ class WebInterface(object):
         return {'definitions': definitions}
 
     @openmotics_api(check=types(confirm=bool), auth=True, plugin_exposed=False)
-    def factory_reset(self, username, password, confirm=False, Can=False):
+    def factory_reset(self, username, password, confirm=False, can=True):
         user_dto = UserDTO(username=username)
         user_dto.set_password(password)
         success, _ = self._user_controller.login(user_dto)
@@ -2385,7 +2385,7 @@ class WebInterface(object):
             raise cherrypy.HTTPError(401, 'invalid_credentials')
         if not confirm:
             raise cherrypy.HTTPError(401, 'not_confirmed')
-        return self._gateway_api.factory_reset(Can=Can)
+        return self._gateway_api.factory_reset(can=can)
 
     @openmotics_api(auth=False)
     def health_check(self):

--- a/src/master/classic/master_api.py
+++ b/src/master/classic/master_api.py
@@ -544,8 +544,8 @@ def erase_can_eeprom():
     """ This instruction will erase the internal and external (if installed) Eeprom of the slave module
     and bring it back to factory reset."""
     return MasterCommandSpec('FX',
-                             [Field.bytes('addr', 4), Field.integer('instr'), Field.crc(), Field.padding(5)],
-                             [Field.bytes('addr', 4), Field.byte('error_code'), Field.crc(), Field.lit('\r\n')])
+                             [Field.bytes('addr', 4), Field.byte('instr'), Field.crc(), Field.padding(5)],
+                             [Field.bytes('addr', 4), Field.byte('error_code'), Field.crc(), Field.padding(5), Field.lit('\r\n')])
 
 
 # Below are the asynchronous messages, sent by the master to the gateway

--- a/src/master/classic/master_api.py
+++ b/src/master/classic/master_api.py
@@ -540,6 +540,14 @@ def get_module_version():
                               Field.crc(), Field.lit('\r\n')])
 
 
+def erase_can_eeprom():
+    """ This instruction will erase the internal and external (if installed) Eeprom of the slave module
+    and bring it back to factory reset."""
+    return MasterCommandSpec('FX',
+                             [Field.bytes('addr', 4), Field.integer('instr'), Field.crc(), Field.padding(5)],
+                             [Field.bytes('addr', 4), Field.byte('error_code'), Field.crc(), Field.lit('\r\n')])
+
+
 # Below are the asynchronous messages, sent by the master to the gateway
 
 def output_list():

--- a/src/master_tool.py
+++ b/src/master_tool.py
@@ -85,7 +85,7 @@ def master_cold_reset(master_controller=INJECTED):
 def master_factory_reset(master_controller=INJECTED):
     # type: (MasterController) -> None
     logger.info('Wiping the master...')
-    master_controller.factory_reset()
+    master_controller.factory_reset(can=True)
     logger.info('Done wiping the master')
 
 

--- a/src/openmotics_cli.py
+++ b/src/openmotics_cli.py
@@ -27,13 +27,15 @@ from ioc import INJECTED, Inject
 logger = logging.getLogger('openmotics')
 
 
-def cmd_factory_reset(args):
+def cmd_factory_reset(args, can):
     lock_file = constants.get_init_lockfile()
     if os.path.isfile(lock_file) and not args.force:
         print('already_in_progress')
         exit(1)
     with open(lock_file, 'w') as fd:
-        fd.write('factory_reset')
+        if can:
+            fd.write('factory_reset_full')
+        else: fd.write('factory_reset')
 
 
 def cmd_shell(args):

--- a/src/openmotics_cli.py
+++ b/src/openmotics_cli.py
@@ -27,13 +27,13 @@ from ioc import INJECTED, Inject
 logger = logging.getLogger('openmotics')
 
 
-def cmd_factory_reset(args, can):
+def cmd_factory_reset(args):
     lock_file = constants.get_init_lockfile()
     if os.path.isfile(lock_file) and not args.force:
         print('already_in_progress')
         exit(1)
     with open(lock_file, 'w') as fd:
-        if can:
+        if args.can:
             fd.write('factory_reset_full')
         else: fd.write('factory_reset')
 
@@ -122,6 +122,7 @@ operator_subparsers = operator_parser.add_subparsers()
 factory_reset_parser = operator_subparsers.add_parser('factory-reset')
 factory_reset_parser.set_defaults(func=cmd_factory_reset)
 factory_reset_parser.add_argument('--force', action='store_true')
+factory_reset_parser.add_argument('--can', action='store_true')
 shell_parser = operator_subparsers.add_parser('shell')
 shell_parser.set_defaults(func=cmd_shell)
 top_parser = operator_subparsers.add_parser('top')

--- a/testing/cicd/tests/toolbox.py
+++ b/testing/cicd/tests/toolbox.py
@@ -415,7 +415,8 @@ class Toolbox(object):
         # TODO: Does not work yet for the Core(+) as they don't have this call implemented.
         logger.debug('Discovering modules')
         since = time.time()
-
+        # [WIP] tried to disable ucan logic for the factory reset test (CAN FX call)
+        # but it did not enable us to check the behaviour
         if ucans:
             ucan_inputs = []
             for module in INPUT_MODULE_LAYOUT:

--- a/testing/cicd/tests/toolbox.py
+++ b/testing/cicd/tests/toolbox.py
@@ -322,7 +322,7 @@ class Toolbox(object):
         # type: (bool) -> Dict[str,Any]
         assert self.dut._auth
         logger.debug('factory reset')
-        params = {'username': self.dut._auth[0], 'password': self.dut._auth[1], 'confirm': confirm}
+        params = {'username': self.dut._auth[0], 'password': self.dut._auth[1], 'confirm': confirm, Can=True}
         return self.dut.get('/factory_reset', params=params, success=confirm)
 
     def list_modules(self):
@@ -420,10 +420,11 @@ class Toolbox(object):
         if ucans:
             ucan_inputs = []
             for module in INPUT_MODULE_LAYOUT:
-                if module.mtype == 'C':
+                if module.is_can:
                     ucan_inputs += module.inputs
             for ucan_input in ucan_inputs:
                 self.tester.toggle_output(ucan_input.tester_output_id, delay=0.5)
+                time.sleep(0.5)
             time.sleep(0.5)  # Give a brief moment for the CC to settle
 
         new_modules = []

--- a/testing/cicd/tests/toolbox.py
+++ b/testing/cicd/tests/toolbox.py
@@ -322,7 +322,7 @@ class Toolbox(object):
         # type: (bool) -> Dict[str,Any]
         assert self.dut._auth
         logger.debug('factory reset')
-        params = {'username': self.dut._auth[0], 'password': self.dut._auth[1], 'confirm': confirm, Can=True}
+        params = {'username': self.dut._auth[0], 'password': self.dut._auth[1], 'confirm': confirm, 'can':True}
         return self.dut.get('/factory_reset', params=params, success=confirm)
 
     def list_modules(self):


### PR DESCRIPTION
```
Apr 27 13:24:32 OpenMotics openmotics-api[20352]: 2021-04-27 13:24:32,447 - root - INFO - Resetting CAN EEPROM, adress: 067.165.162.156

Apr 27 13:24:32 OpenMotics openmotics-api[20352]: 2021-04-27 13:24:32,456 - gateway.master.classic - DEBUG - Writing to Master serial:    83  84  82  70  88  29  67 165 162 156   0   0  67   2 196   0   0   0   0   0  13  10    STRFX.C.....C.........
Apr 27 13:24:32 OpenMotics openmotics-api[20352]: 2021-04-27 13:24:32,469 - gateway.master.classic - DEBUG - Reading from Master serial:  70  88  29  67 165    FX.C.
Apr 27 13:24:32 OpenMotics openmotics-api[20352]: 2021-04-27 13:24:32,477 - gateway.master.classic - DEBUG - Reading from Master serial: 162 156   4  67   2 200  13  10  13  10   7  13  10    ...C.........
```
Lijkt niet effectief te resetten
