### PR TITLE
Fix unnecessary broadcasting of input_status events to plugins

### DIFF
--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -394,8 +394,12 @@ class PluginController(object):
     def process_observer_event(self, event):
         if event.type == GatewayEvent.Types.INPUT_CHANGE:
             # Should be called when the input status changes, notifies all plugins.
+            input_id = event.data['id']
+            input_status = event.data['status']
             for runner in self._iter_running_runners():
-                runner.process_input_status(event)
+                if input_status:  # Backwards compatibility: only send rising edges of the input for v1
+                    runner.process_input_status(data=(input_id, None), action_version=1)
+                runner.process_input_status(data=event, action_version=2)
         if event.type == GatewayEvent.Types.OUTPUT_CHANGE:
             # TODO: deprecate old versions that use state and move to events
             states = [(state.id, state.dimmer) for state in self._output_controller.get_output_statuses() if state.status]

--- a/src/plugins/runner.py
+++ b/src/plugins/runner.py
@@ -244,9 +244,16 @@ class PluginRunner(object):
                 self._state_callback(self.name, PluginRunner.State.STOPPED)
             self.logger('[Runner] Stopped')
 
-    def process_input_status(self, input_event):
-        event_json = input_event.serialize()
-        self._do_async(action='input_status', payload={'event': event_json}, should_filter=False)
+    def process_input_status(self, data, action_version=1):
+        if action_version in [1, 2]:
+            if action_version == 1:
+                payload = {'status': data}
+            else:
+                event_json = data.serialize()
+                payload = {'event': event_json}
+            self._do_async(action='input_status', payload=payload, should_filter=True, action_version=action_version)
+        else:
+            self.logger('Input status version {} not supported.'.format(action_version))
 
     def process_output_status(self, data, action_version=1):
         if action_version in [1, 2]:


### PR DESCRIPTION
In a previous PR (https://github.com/openmotics/gateway/pull/662), a fix was made for input_status decorators with a version > 1. This PR however sends all input_status events to all plugins, even if they are not registered for these events. 

This PR uses the same approach for the versioned input_status decorator as with output_status and hence, avoids unnecessary broadcasting of events to unsubscribed plugins.