### PR TITLE
OM-2110 fix for update exit code

### DIFF
--- a/src/openmotics_update.py
+++ b/src/openmotics_update.py
@@ -453,7 +453,6 @@ def update(version, expected_md5):
         raise SystemExit(EXIT_CODES['failed_preprepare_update'])
 
     errors = []
-    sysex_errors = []
     services_running = True
     try:
         date = datetime.now().strftime('%Y%m%d%H%M%S')

--- a/src/openmotics_update.py
+++ b/src/openmotics_update.py
@@ -532,6 +532,11 @@ def update(version, expected_md5):
         logger.info(' -> Waiting for health check')
         check_gateway_health()
 
+    except SystemExit as sex:
+        logger.error('FAILED')
+        logger.error('exit ({}) : {}'.format(sex.code, sex))
+        logger.error(traceback.format_exc())
+
     except Exception as exc:
         logger.exception('Unexpected exception updating')
         errors.append(exc)

--- a/src/openmotics_update.py
+++ b/src/openmotics_update.py
@@ -453,6 +453,7 @@ def update(version, expected_md5):
         raise SystemExit(EXIT_CODES['failed_preprepare_update'])
 
     errors = []
+    sysex_errors = []
     services_running = True
     try:
         date = datetime.now().strftime('%Y%m%d%H%M%S')
@@ -536,6 +537,7 @@ def update(version, expected_md5):
         logger.error('FAILED')
         logger.error('exit ({}) : {}'.format(sex.code, sex))
         logger.error(traceback.format_exc())
+        sysex_errors.append(sex)
 
     except Exception as exc:
         logger.exception('Unexpected exception updating')
@@ -548,6 +550,13 @@ def update(version, expected_md5):
 
         logger.info(' -> Running cleanup')
         cmd('rm -v -rf {}/*'.format(update_dir), shell=True)
+
+        if sysex_errors:
+            logger.error('SystemExit Exceptions:')
+            for error in sysex_errors:
+                logger.error('- {0}'.format(error))
+            raise sysex_errors[0]
+
 
         if errors:
             logger.error('Exceptions:')


### PR DESCRIPTION
a SystemExit exception raised by check_gateway_health() will be handled before the finally block - It would be even better to refactor the finally block.
Catching the SystemExit earlyer only avoids confusing logs where "done" and "exit 0" are followed by exit 4 [failed_health_check].