### PR TITLE
translate types in master sensor events

### DIFF
--- a/testing/unittests/gateway_tests/sensor_controller_test.py
+++ b/testing/unittests/gateway_tests/sensor_controller_test.py
@@ -80,7 +80,7 @@ class SensorControllerTest(unittest.TestCase):
         assert len(events) == 1
         events.pop()
 
-        master_event = MasterEvent(MasterEvent.Types.SENSOR_VALUE, {'sensor': 1, 'type': 'temperature', 'value': 22.5})
+        master_event = MasterEvent(MasterEvent.Types.SENSOR_VALUE, {'sensor': 1, 'type': 'TEMPERATURE', 'value': 22.5})
         self.pubsub.publish_master_event(PubSub.MasterTopics.SENSOR, master_event)
         self.pubsub._publish_all_events()
 


### PR DESCRIPTION
The physical quantities are lowercase so these events didn't lookup the
cached master sensors correctly.