### PR TITLE
return None for invalid thermostat sensors

### DIFF
--- a/src/gateway/thermostat/master/thermostat_controller_master.py
+++ b/src/gateway/thermostat/master/thermostat_controller_master.py
@@ -181,8 +181,12 @@ class ThermostatControllerMaster(ThermostatController):
                 .where(Sensor.source == Sensor.Sources.MASTER) \
                 .where(Sensor.physical_quantity == Sensor.PhysicalQuantities.TEMPERATURE) \
                 .where(Sensor.external_id == str(sensor_id)) \
-                .get()
-            return sensor.id
+                .first()
+            if sensor is None:
+                logger.warning('Invalid <Sensor external_id={}> configured on thermostat', sensor_id)
+                return None
+            else:
+                return sensor.id
 
     def _sensor_to_master(self, sensor_id):  # type: (Optional[int]) -> Optional[int]
         if sensor_id in (None, 240, 255):


### PR DESCRIPTION
It's possible for a sensor_id without temperature to be configured
before the sensor orm changes or through maintenance mode.