### PR TITLE
Fixed leak in plugin runners

### DIFF
--- a/src/plugin_runtime/runtime.py
+++ b/src/plugin_runtime/runtime.py
@@ -400,6 +400,7 @@ class PluginRuntime(object):
         except Exception as exception:
             return {'success': False, 'exception': str(exception), 'stacktrace': traceback.format_exc()}
 
+
 def start_runtime(plugin_location=None):
     if plugin_location is None and (len(sys.argv) < 3 or sys.argv[1] != 'start_plugin'):
         sys.stderr.write('Usage: python {0} start_plugin <path>\n'.format(sys.argv[0]))

--- a/src/plugins/runner.py
+++ b/src/plugins/runner.py
@@ -507,15 +507,24 @@ class RunnerWatchdog(object):
         self._plugin_runner.logger('[Watchdog] Stopped')
 
     def _run(self):
+        starting = False
         try:
             score = self._plugin_runner.error_score()
             if score > self._threshold:
+                starting = False
                 self._plugin_runner.logger('[Watchdog] Stopping unhealthy runner')
                 self._plugin_runner.stop()
             if not self._plugin_runner.is_running():
+                starting = True
                 self._plugin_runner.logger('[Watchdog] Starting stopped runner')
                 self._plugin_runner.start()
             return True
         except Exception as e:
-            self._plugin_runner.logger('[Watchdog] Exception in watchdog: {0}'.format(e))
+            sting = 'starting' if starting else 'stopping'
+            self._plugin_runner.logger('[Watchdog] Exception while {0} runner: {1}'.format(sting, e))
+            try:
+                self._plugin_runner.logger('[Watchdog] Stopping failed runner')
+                self._plugin_runner.stop()
+            except Exception as se:
+                self._plugin_runner.logger('[Watchdog] Exception while {0} failed runner: {1}'.format(sting, se))
             return False

--- a/src/plugins/runner.py
+++ b/src/plugins/runner.py
@@ -520,11 +520,12 @@ class RunnerWatchdog(object):
                 self._plugin_runner.start()
             return True
         except Exception as e:
-            sting = 'starting' if starting else 'stopping'
-            self._plugin_runner.logger('[Watchdog] Exception while {0} runner: {1}'.format(sting, e))
+            self._plugin_runner.logger('[Watchdog] Exception while {0} runner: {1}'.format(
+                'starting' if starting else 'stopping', e
+            ))
             try:
                 self._plugin_runner.logger('[Watchdog] Stopping failed runner')
                 self._plugin_runner.stop()
             except Exception as se:
-                self._plugin_runner.logger('[Watchdog] Exception while {0} failed runner: {1}'.format(sting, se))
+                self._plugin_runner.logger('[Watchdog] Exception while stopping failed runner: {0}'.format(se))
             return False

--- a/testing/unittests/plugins_tests/runner_test.py
+++ b/testing/unittests/plugins_tests/runner_test.py
@@ -23,7 +23,8 @@ import shutil
 import tempfile
 import unittest
 import xmlrunner
-from plugins.runner import PluginRunner
+import mock
+from plugins.runner import PluginRunner, RunnerWatchdog
 
 
 class PluginRunnerTest(unittest.TestCase):
@@ -45,11 +46,73 @@ class PluginRunnerTest(unittest.TestCase):
             pass
 
     def _log(self, *args, **kwargs):
-        _ = args, kwargs
+        print(args)
+        print(kwargs)
+        _ = self, args, kwargs
 
     def test_queue_length(self):
-        runner = PluginRunner('foo', self.RUNTIME_PATH, self.PLUGIN_PATH, self._log)
+        runner = PluginRunner(name='foo',
+                              runtime_path=self.RUNTIME_PATH,
+                              plugin_path=self.PLUGIN_PATH,
+                              logger=self._log)
         self.assertEqual(runner.get_queue_length(), 0)
+
+    def test_watchog_always_stops_runner(self):
+
+        def _set_side_effects(effects):
+            error_score.side_effect = effects[0]
+            start.side_effect = effects[1]
+            stop.side_effect = effects[2]
+            is_running.side_effect = effects[3]
+
+        def _reset():
+            error_score.reset_mock()
+            start.reset_mock()
+            stop.reset_mock()
+            is_running.reset_mock()
+
+        runner = PluginRunner(name='foo',
+                              runtime_path=self.RUNTIME_PATH,
+                              plugin_path=self.PLUGIN_PATH,
+                              logger=self._log)
+        watchdog = RunnerWatchdog(plugin_runner=runner)
+        watchdog.logger = self._log
+        with mock.patch.object(runner, 'error_score') as error_score, \
+                mock.patch.object(runner, 'start') as start, \
+                mock.patch.object(runner, 'stop') as stop, \
+                mock.patch.object(runner, 'is_running') as is_running:
+            for scenario in [{'side_effects': [[0.0], [None], [None], [True]],  # Everything is good
+                              'result': True,
+                              'calls': [1, 0, 0, 1]},
+                             {'side_effects': [[0.0], [None], [None], [False]],  # The runner was not running and is started
+                              'result': True,
+                              'calls': [1, 1, 0, 1]},
+                             {'side_effects': [[1.0], [None], [None], [False]],  # The runner is unhealthy and is stopped, and then started again
+                              'result': True,
+                              'calls': [1, 1, 1, 1]},
+                             {'side_effects': [[RuntimeError()], [None], [None], [False]],  # Exception while requesting score, unhealthy runner is stopped
+                              'result': False,
+                              'calls': [1, 0, 1, 0]},
+                             {'side_effects': [[1.0], [None], [RuntimeError()], [False]],  # Exception while stopping unhealthy runner, failed runner is stopped
+                              'result': False,
+                              'calls': [1, 0, 2, 0]},
+                             {'side_effects': [[0.0], [RuntimeError()], [None], [False]],  # Exception while starting stopped runner, failed runner is stopped
+                              'result': False,
+                              'calls': [1, 1, 1, 1]},
+                             {'side_effects': [[1.0], [None], [RuntimeError(), RuntimeError()], [False]],  # Exception while stopping unhealthy runner, failed runner is stopped. And that stop also fails
+                              'result': False,
+                              'calls': [1, 0, 2, 0]}]:
+                _reset()
+                _set_side_effects(scenario['side_effects'])
+                result = watchdog._run()
+                self.assertEqual(scenario['result'], result)
+                for i, _mock in enumerate([error_score, start, stop, is_running]):
+                    if scenario['calls'][i] == 0:
+                        _mock.assert_not_called()
+                    elif scenario['calls'][i] == 1:
+                        _mock.assert_called_once()
+                    else:
+                        self.assertEqual(scenario['calls'][i], _mock.call_count)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Symptoms:
* `ps faux | grep python`: A lot of identical plugins running
* `ls -al /proc/<pid openmotics_service.py>/fd/*`: A lot of open file descriptors, most of them pipes towards the runners