### PR TITLE
Add a blocking argument to the _publish_all_events pubsub function

### DIFF
--- a/src/gateway/pubsub.py
+++ b/src/gateway/pubsub.py
@@ -86,10 +86,10 @@ class PubSub(object):
         while self._is_running:
             self._publish_all_events()
 
-    def _publish_all_events(self):
+    def _publish_all_events(self, blocking=True):
         while True:
             try:
-                event = self._master_events.get(block=True, timeout=0.25)
+                event = self._master_events.get(block=blocking, timeout=0.25)
                 if event is None:
                     return
                 self._publish_master_event(*event)
@@ -97,7 +97,7 @@ class PubSub(object):
                 break
         while True:
             try:
-                event = self._gateway_events.get(block=True, timeout=0.25)
+                event = self._gateway_events.get(block=blocking, timeout=0.25)
                 if event is None:
                     return
                 self._publish_gateway_event(*event)
@@ -105,7 +105,7 @@ class PubSub(object):
                 break
         while True:
             try:
-                event = self._esafe_events.get(block=True, timeout=0.25)
+                event = self._esafe_events.get(block=blocking, timeout=0.25)
                 if event is None:
                     return
                 self._publish_esafe_event(*event)

--- a/testing/unittests/gateway_tests/input_controller_test.py
+++ b/testing/unittests/gateway_tests/input_controller_test.py
@@ -74,7 +74,7 @@ class InputControllerTest(unittest.TestCase):
         input_dto = InputDTO(id=42)
         with mock.patch.object(self.master_controller, 'load_inputs', return_value=[input_dto]):
             self.controller.run_sync_orm()
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             assert Input.select().where(Input.number == input_dto.id).count() == 1
             assert GatewayEvent(GatewayEvent.Types.CONFIG_CHANGE, {'type': 'input'}) in events
             assert len(events) == 1
@@ -154,7 +154,7 @@ class InputControllerTest(unittest.TestCase):
                                              InputStatusDTO(id=40, status=True)]):
             self.controller.load_inputs()
             self.controller._sync_state()
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             self.assertListEqual([GatewayEvent('INPUT_CHANGE',
                                   {'id': 2, 'status': True, "location": {"room_id": 255}}),
                                   GatewayEvent('INPUT_CHANGE',
@@ -171,7 +171,7 @@ class InputControllerTest(unittest.TestCase):
                                              InputStatusDTO(id=40, status=False)]):
             events = []
             self.controller._sync_state()
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             self.assertListEqual([GatewayEvent('INPUT_CHANGE',
                                   {'id': 2, 'status': True, "location": {"room_id": 255}}),
                                   GatewayEvent('INPUT_CHANGE',
@@ -209,7 +209,7 @@ class InputControllerTest(unittest.TestCase):
         #         self.controller.start()
         #         # after >10 seconds delay, the controller should publish events at startup
         #         frozen_datetime.tick(delta=datetime.timedelta(seconds=15))
-        #         self.pubsub._publish_all_events()
+        #         self.pubsub._publish_all_events(blocking=False)
         #         self.assertListEqual([GatewayEvent('INPUT_CHANGE',
         #                                            {'id': 2, 'status': True, "location": {"room_id": 255}}),
         #                               GatewayEvent('INPUT_CHANGE',
@@ -217,7 +217,7 @@ class InputControllerTest(unittest.TestCase):
         #         # after >10 more minutes, the controller should also periodically publish events regardless of changes
         #         events = []
         #         frozen_datetime.tick(delta=datetime.timedelta(minutes=11))
-        #         self.pubsub._publish_all_events()
+        #         self.pubsub._publish_all_events(blocking=False)
         #         self.assertListEqual([GatewayEvent('INPUT_CHANGE',
         #                                            {'id': 2, 'status': True, "location": {"room_id": 255}}),
         #                               GatewayEvent('INPUT_CHANGE',

--- a/testing/unittests/gateway_tests/pubsub_test.py
+++ b/testing/unittests/gateway_tests/pubsub_test.py
@@ -53,12 +53,12 @@ class PubSubTest(unittest.TestCase):
 
         event = GatewayEvent(GatewayEvent.Types.INPUT_CHANGE, {'data': 'Some Test Data'})
         self.pubsub.publish_gateway_event(PubSub.GatewayTopics.STATE, event)
-        self.pubsub._publish_all_events()
+        self.pubsub._publish_all_events(blocking=False)
         self.sub_gateway_mock.assert_called_once_with(event)
 
         event = EsafeEvent(EsafeEvent.Types.DELIVERY_CHANGE, {'delivery_id': 37, 'delivery_type': 'RETURN'})
         self.pubsub.publish_esafe_event(PubSub.EsafeTopics.DELIVERY, event)
-        self.pubsub._publish_all_events()
+        self.pubsub._publish_all_events(blocking=False)
         self.sub_esafe_mock.assert_called_once_with(event)
 
     def test_pubsub_multiple(self):
@@ -69,7 +69,7 @@ class PubSubTest(unittest.TestCase):
             self.pubsub.publish_gateway_event(PubSub.GatewayTopics.STATE, gw_event)
         for _ in range(num_events):
             self.pubsub.publish_esafe_event(PubSub.EsafeTopics.DELIVERY, es_event)
-        self.pubsub._publish_all_events()
+        self.pubsub._publish_all_events(blocking=False)
         self.sub_gateway_mock.assert_has_calls([call(gw_event) for _ in range(num_events)], any_order=False)
         self.sub_esafe_mock.assert_has_calls([call(es_event) for _ in range(num_events)], any_order=False)
         self.assertEqual(self.sub_gateway_mock.call_count, num_events)
@@ -82,7 +82,7 @@ class PubSubTest(unittest.TestCase):
         self.pubsub.publish_gateway_event(PubSub.GatewayTopics.CONFIG, gw_event)
         self.pubsub.publish_esafe_event(PubSub.EsafeTopics.DELIVERY, es_event_1)
         self.pubsub.publish_esafe_event(PubSub.EsafeTopics.LOCK, es_event_2)
-        self.pubsub._publish_all_events()
+        self.pubsub._publish_all_events(blocking=False)
         self.sub_gateway_mock.assert_not_called()
         self.sub_esafe_mock.assert_called_once_with(es_event_1)
 
@@ -95,6 +95,6 @@ class PubSubTest(unittest.TestCase):
             'parcel_rebus_id': 37
         })
         self.pubsub.publish_esafe_event(PubSub.EsafeTopics.DELIVERY, event)
-        self.pubsub._publish_all_events()
+        self.pubsub._publish_all_events(blocking=False)
         self.sub_gateway_mock.assert_not_called()
         self.sub_esafe_mock.assert_called_once_with(event)

--- a/testing/unittests/gateway_tests/sensor_controller_test.py
+++ b/testing/unittests/gateway_tests/sensor_controller_test.py
@@ -75,14 +75,14 @@ class SensorControllerTest(unittest.TestCase):
              mock.patch.object(self.master_controller, 'get_sensors_humidity', return_value=[None]), \
              mock.patch.object(self.master_controller, 'get_sensors_temperature', return_value=[None, 21.0, None]):
             self.controller.run_sync_orm()
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
         assert GatewayEvent('SENSOR_CHANGE', {'id': 42, 'value': 21.0}) in events
         assert len(events) == 1
         events.pop()
 
         master_event = MasterEvent(MasterEvent.Types.SENSOR_VALUE, {'sensor': 1, 'type': 'TEMPERATURE', 'value': 22.5})
         self.pubsub.publish_master_event(PubSub.MasterTopics.SENSOR, master_event)
-        self.pubsub._publish_all_events()
+        self.pubsub._publish_all_events(blocking=False)
 
         assert GatewayEvent('SENSOR_CHANGE', {'id': 42, 'value': 22.5}) in events
         assert len(events) == 1
@@ -105,7 +105,7 @@ class SensorControllerTest(unittest.TestCase):
              mock.patch.object(self.master_controller, 'get_sensors_humidity', return_value=[None, None, 49.0]), \
              mock.patch.object(self.master_controller, 'get_sensors_temperature', return_value=[21.0, None, None]):
             self.controller.run_sync_orm()
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
         assert GatewayEvent('CONFIG_CHANGE', {'type': 'sensor'}) in events
         assert len(events) == 1
 
@@ -144,7 +144,7 @@ class SensorControllerTest(unittest.TestCase):
              mock.patch.object(self.master_controller, 'get_sensors_humidity', return_value=[None, 49.0]), \
              mock.patch.object(self.master_controller, 'get_sensors_temperature', return_value=[None, 21.0]):
             self.controller.run_sync_orm()
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
         assert GatewayEvent('CONFIG_CHANGE', {'type': 'sensor'}) in events
         assert len(events) == 1
 
@@ -176,7 +176,7 @@ class SensorControllerTest(unittest.TestCase):
              mock.patch.object(self.master_controller, 'get_sensors_temperature', return_value=[21.0, None, None]):
             self.controller.run_sync_orm()
             self.controller.run_sync_orm()  # recover after failed sync
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
         assert Sensor.select().count() == 3
         sensor_ids = list(i for (i,) in Sensor.select(Sensor.id).tuples())
@@ -223,7 +223,7 @@ class SensorControllerTest(unittest.TestCase):
         sensor_dto = SensorDTO(id=42, physical_quantity='temperature', unit='celcius', name='foo', room=2)
         with mock.patch.object(self.master_controller, 'save_sensors') as save:
             self.controller.save_sensors([sensor_dto])
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             save.assert_called_with([MasterSensorDTO(id=0, name='foo')])
 
         assert GatewayEvent('CONFIG_CHANGE', {'type': 'sensor'}) in events
@@ -253,7 +253,7 @@ class SensorControllerTest(unittest.TestCase):
                                name='foo')
         with mock.patch.object(self.master_controller, 'save_sensors') as save:
             self.controller.save_sensors([sensor_dto])
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             save.assert_not_called()
 
         assert GatewayEvent('CONFIG_CHANGE', {'type': 'sensor'}) in events
@@ -284,7 +284,7 @@ class SensorControllerTest(unittest.TestCase):
                                name='foo')
         with mock.patch.object(self.master_controller, 'save_sensors') as save:
             self.controller.save_sensors([sensor_dto])
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             save.assert_not_called()
 
         assert GatewayEvent('CONFIG_CHANGE', {'type': 'sensor'}) in events
@@ -314,7 +314,7 @@ class SensorControllerTest(unittest.TestCase):
                                virtual=True)
         with mock.patch.object(self.master_controller, 'save_sensors') as save:
             self.controller.save_sensors([sensor_dto])
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             save.assert_called_with([MasterSensorDTO(id=31, name='foo', virtual=True)])
 
         assert GatewayEvent('CONFIG_CHANGE', {'type': 'sensor'}) in events
@@ -342,7 +342,7 @@ class SensorControllerTest(unittest.TestCase):
              mock.patch.object(self.master_controller, 'get_sensors_humidity', return_value=[None, None, 49.0]), \
              mock.patch.object(self.master_controller, 'get_sensors_temperature', return_value=[21.0, None, None]):
             self.controller.run_sync_orm()
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             values = {s.id: s for s in self.controller.get_sensors_status()}
 
         assert Sensor.select().count() == 3

--- a/testing/unittests/gateway_tests/thermostat/master/thermostat_controller_master_test.py
+++ b/testing/unittests/gateway_tests/thermostat/master/thermostat_controller_master_test.py
@@ -58,7 +58,7 @@ class ThermostatControllerMasterTest(unittest.TestCase):
                       'output1': None}
             self.controller._thermostats_config = {1: ThermostatDTO(1)}
             self.controller._thermostat_status._report_change(1, status)
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             event_data = {'id': 1,
                           'status': {'preset': 'AUTO',
                                      'current_setpoint': None,
@@ -72,7 +72,7 @@ class ThermostatControllerMasterTest(unittest.TestCase):
         master_event = MasterEvent(MasterEvent.Types.EEPROM_CHANGE, {})
         with mock.patch.object(self.controller, 'invalidate_cache') as handle_event:
             self.pubsub.publish_master_event(PubSub.MasterTopics.EEPROM, master_event)
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             handle_event.assert_called()
 
     def test_saving_reading_sane_values(self):

--- a/testing/unittests/gateway_tests/ventilation_controller_test.py
+++ b/testing/unittests/gateway_tests/ventilation_controller_test.py
@@ -242,12 +242,12 @@ class VentilationControllerTest(unittest.TestCase):
                                              device_type='model-0',
                                              device_serial='device-000001')
             self.controller.save_ventilation(ventilation_dto)
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             assert len(events) == 0, events  # No change
 
             ventilation_dto.name = 'bar'
             self.controller.save_ventilation(ventilation_dto)
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             assert GatewayEvent(GatewayEvent.Types.CONFIG_CHANGE, {'type': 'ventilation'}) in events
             assert len(events) == 1, events
 
@@ -263,7 +263,7 @@ class VentilationControllerTest(unittest.TestCase):
                                return_value=[get_ventilation(42), get_ventilation(43)]):
             self.controller.set_status(VentilationStatusDTO(42, 'manual', level=0))
             self.controller.set_status(VentilationStatusDTO(43, 'manual', level=2, timer=60.0))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             events = []
 
@@ -273,7 +273,7 @@ class VentilationControllerTest(unittest.TestCase):
 
             self.controller.set_status(VentilationStatusDTO(42, 'manual', level=0))
             self.controller.set_status(VentilationStatusDTO(43, 'manual', level=2, timer=60.0))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             assert GatewayEvent(GatewayEvent.Types.VENTILATION_CHANGE,
                                 {'id': 43, 'mode': 'manual', 'level': 2, 'timer': 60.0,
                                  'remaining_time': None,'is_connected': True}) in events
@@ -297,7 +297,7 @@ class VentilationControllerTest(unittest.TestCase):
 
             self.controller.set_status(VentilationStatusDTO(43, 'manual', level=2, timer=60.0,
                                                             last_seen=(time.time() - 600)))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             assert GatewayEvent(GatewayEvent.Types.VENTILATION_CHANGE,
                                 {'id': 43, 'mode': 'manual', 'level': 2, 'timer': 60.0,
@@ -322,13 +322,13 @@ class VentilationControllerTest(unittest.TestCase):
 
             self.controller.set_status(VentilationStatusDTO(43, 'manual', level=2, timer=60.0,
                                                             last_seen=(time.time() - 600)))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertEqual(1, len(events))
             self.assertEqual(1, len(self.controller._status))
 
             self.controller._check_connected_timeout()
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             self.assertEqual(2, len(events))
             self.assertEqual(1, len(self.controller._status))
 
@@ -338,13 +338,13 @@ class VentilationControllerTest(unittest.TestCase):
             self.assertEqual(None, last_event.data['level'])
 
             self.controller.set_status(VentilationStatusDTO(43, 'manual', level=2, timer=60.0))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertEqual(3, len(events))
             self.assertEqual(1, len(self.controller._status))
 
             self.controller._check_connected_timeout()
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             # Now there would no timeout occur
             self.assertEqual(3, len(events))
             self.assertEqual(1, len(self.controller._status))
@@ -368,7 +368,7 @@ class VentilationControllerTest(unittest.TestCase):
             # first timer is running
             self.controller.set_status(VentilationStatusDTO(43, 'manual', level=2, timer=60.0, remaining_time=5.0,
                                                             last_seen=(time.time() - 10)))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertEqual(1, len(events))
             self.assertEqual(1, len(self.controller._status))
@@ -377,7 +377,7 @@ class VentilationControllerTest(unittest.TestCase):
             self.controller._check_connected_timeout()
             # This should trigger an update event.
             self.controller._periodic_event_update()
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
             self.assertEqual(2, len(events))
             self.assertEqual(1, len(self.controller._status))
 
@@ -387,7 +387,7 @@ class VentilationControllerTest(unittest.TestCase):
             # event that timer has been done
             self.controller.set_status(VentilationStatusDTO(43, 'automatic', level=1, timer=None, remaining_time=None,
                                                             last_seen=time.time()))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertEqual(1, len(events))
             self.assertEqual(1, len(self.controller._status))
@@ -400,7 +400,7 @@ class VentilationControllerTest(unittest.TestCase):
             # event that timer has been started
             self.controller.set_status(VentilationStatusDTO(43, 'automatic', level=1, timer=30, remaining_time=None,
                                                             last_seen=time.time()))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertEqual(1, len(events))
             self.assertEqual(1, len(self.controller._status))
@@ -413,7 +413,7 @@ class VentilationControllerTest(unittest.TestCase):
             # event from ventilation plugin
             self.controller.set_status(VentilationStatusDTO(43, 'manual', level=1, timer=None, remaining_time=29,
                                                             last_seen=time.time()))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertEqual(1, len(events))
             self.assertEqual(1, len(self.controller._status))
@@ -426,7 +426,7 @@ class VentilationControllerTest(unittest.TestCase):
             # event from ventilation plugin
             self.controller.set_status(VentilationStatusDTO(43, 'automatic', level=1, timer=None, remaining_time=15,
                                                             last_seen=time.time()))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertEqual(1, len(events))
             self.assertEqual(1, len(self.controller._status))
@@ -439,7 +439,7 @@ class VentilationControllerTest(unittest.TestCase):
             # event from ventilation plugin (same value)
             self.controller.set_status(VentilationStatusDTO(43, 'automatic', level=1, timer=None, remaining_time=15,
                                                             last_seen=time.time()))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertEqual(0, len(events))
             self.assertEqual(1, len(self.controller._status))
@@ -447,7 +447,7 @@ class VentilationControllerTest(unittest.TestCase):
             # event from ventilation plugin
             self.controller.set_status(VentilationStatusDTO(43, 'automatic', level=1, timer=None, remaining_time=14,
                                                             last_seen=time.time()))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertEqual(1, len(events))
             self.assertEqual(1, len(self.controller._status))
@@ -460,7 +460,7 @@ class VentilationControllerTest(unittest.TestCase):
             # event from ventilation plugin -> Timer has expired, but is still in manual mode
             self.controller.set_status(VentilationStatusDTO(43, 'manual', level=1, timer=None, remaining_time=None,
                                                             last_seen=time.time()))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertEqual(1, len(events))
             self.assertEqual(1, len(self.controller._status))
@@ -486,7 +486,7 @@ class VentilationControllerTest(unittest.TestCase):
             # event that ventilation box is running in automatic mode
             self.controller.set_status(VentilationStatusDTO(43, 'automatic', level=1, timer=None, remaining_time=None,
                                                             last_seen=time.time()))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertEqual(1, len(events))
             self.assertEqual(1, len(self.controller._status))
@@ -499,7 +499,7 @@ class VentilationControllerTest(unittest.TestCase):
             # event that timer has been started
             self.controller.set_status(VentilationStatusDTO(43, 'automatic', level=1, timer=30, remaining_time=None,
                                                             last_seen=time.time()))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertEqual(1, len(events))
             self.assertEqual(1, len(self.controller._status))
@@ -514,7 +514,7 @@ class VentilationControllerTest(unittest.TestCase):
                 mode = 'automatic' if i % 2 == 0 else 'manual'
                 self.controller.set_status(VentilationStatusDTO(43, mode, level=1, timer=None, remaining_time=i,
                                                                 last_seen=time.time()))
-                self.pubsub._publish_all_events()
+                self.pubsub._publish_all_events(blocking=False)
 
                 self.assertEqual(1, len(events))
                 self.assertEqual(1, len(self.controller._status))
@@ -527,7 +527,7 @@ class VentilationControllerTest(unittest.TestCase):
             # event from ventilation plugin -> Timer has expired, and has switched to automatic mode
             self.controller.set_status(VentilationStatusDTO(43, 'automatic', level=1, timer=None, remaining_time=None,
                                                             last_seen=time.time()))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertEqual(1, len(events))
             self.assertEqual(1, len(self.controller._status))
@@ -583,14 +583,14 @@ class VentilationControllerTest(unittest.TestCase):
                     remaining_time=event.data['timer'],
                 )
                 self.controller.set_status(status_dto)
-                self.pubsub._publish_all_events()
+                self.pubsub._publish_all_events(blocking=False)
 
             self.pubsub.subscribe_gateway_events(PubSub.GatewayTopics.STATE, callback)
 
             # event that ventilation box is running in automatic mode
             self.controller.set_status(VentilationStatusDTO(43, 'automatic', level=1, timer=None, remaining_time=None,
                                                             last_seen=time.time()))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertEqual(1, len(events))
 
@@ -600,20 +600,20 @@ class VentilationControllerTest(unittest.TestCase):
             # event that timer has been started
             self.controller.set_status(VentilationStatusDTO(43, 'manual', level=1, timer=30, remaining_time=None,
                                                             last_seen=time.time()))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertGreaterEqual(10, len(events))
 
             # event that timer is running
             self.controller.set_status(VentilationStatusDTO(43, 'manual', level=1, timer=None, remaining_time=15,
                                                             last_seen=time.time()))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertGreaterEqual(10, len(events))
 
             # event that timer is done
             self.controller.set_status(VentilationStatusDTO(43, 'automatic', level=1, timer=None, remaining_time=None,
                                                             last_seen=time.time()))
-            self.pubsub._publish_all_events()
+            self.pubsub._publish_all_events(blocking=False)
 
             self.assertGreaterEqual(10, len(events))

--- a/testing/unittests/master_tests/eeprom_controller_test.py
+++ b/testing/unittests/master_tests/eeprom_controller_test.py
@@ -452,12 +452,12 @@ class EepromControllerTest(unittest.TestCase):
 
         get_pubsub().subscribe_master_events(PubSub.MasterTopics.EEPROM, handle_events)
         controller.invalidate_cache()
-        get_pubsub()._publish_all_events()
+        get_pubsub()._publish_all_events(blocking=False)
         self.assertEqual([
             MasterEvent(MasterEvent.Types.EEPROM_CHANGE, {})
         ], events)
         controller.activate()
-        get_pubsub()._publish_all_events()
+        get_pubsub()._publish_all_events(blocking=False)
         self.assertEqual([
             MasterEvent(MasterEvent.Types.EEPROM_CHANGE, {}),
             MasterEvent(MasterEvent.Types.EEPROM_CHANGE, {})

--- a/testing/unittests/power_tests/energy_module_controller_test.py
+++ b/testing/unittests/power_tests/energy_module_controller_test.py
@@ -157,7 +157,7 @@ class EnergyModuleControllerTest(unittest.TestCase):
 
         master_event = MasterEvent(MasterEvent.Types.POWER_ADDRESS_EXIT, {})
         self.pubsub.publish_master_event(PubSub.MasterTopics.POWER, master_event)
-        self.pubsub._publish_all_events()
+        self.pubsub._publish_all_events(blocking=False)
 
         assert GatewayEvent(GatewayEvent.Types.CONFIG_CHANGE, {'type': 'powermodule'}) in events
         assert len(events) == 1

--- a/testing/unittests/power_tests/power_communicator_test.py
+++ b/testing/unittests/power_tests/power_communicator_test.py
@@ -177,12 +177,12 @@ class EnergyCommunicatorTest(unittest.TestCase):
 
         self.communicator.start_address_mode()
         self.assertTrue(self.communicator.in_address_mode())
-        self.pubsub._publish_all_events()
+        self.pubsub._publish_all_events(blocking=False)
         time.sleep(0.5)
         assert [] == events
 
         self.communicator.stop_address_mode()
-        self.pubsub._publish_all_events()
+        self.pubsub._publish_all_events(blocking=False)
         assert MasterEvent(MasterEvent.Types.POWER_ADDRESS_EXIT, {}) in events
         assert len(events) == 1
 


### PR DESCRIPTION
Speeding up the unit tests by making the pubsub publish function non blocking for testing purposes.

Current runtime:
2m21

previous runtime:
5m57