### PR TITLE
Fix create user in V0 api as SUPER user

### DIFF
--- a/src/gateway/webservice.py
+++ b/src/gateway/webservice.py
@@ -238,7 +238,7 @@ def authentication_handler(pass_token=False, pass_role=False, version=0):
         # check if the call is done from localhost, and then verify the token
         if request.remote.ip != '127.0.0.1':
             if checked_token is None:
-                raise RuntimeError()
+                raise RuntimeError('Call is not performed from localhost and no token is provided')
             if checked_token.user.role != 'SUPER':
                 raise RuntimeError('User is non SUPER, need SUPER to access V0 api')
         if pass_token is True:
@@ -251,10 +251,10 @@ def authentication_handler(pass_token=False, pass_role=False, version=0):
                 request.params['role'] = 'ADMIN'
             else:
                 request.params['role'] = checked_token.user.role
-    except Exception:
+    except Exception as ex:
         cherrypy.response.headers['Content-Type'] = 'application/json'
         cherrypy.response.status = 401  # Unauthorized
-        contents = json.dumps({'success': False, 'msg': 'invalid_token'})
+        contents = json.dumps({'success': False, 'msg': 'invalid_token', 'detail': str(ex)})
         cherrypy.response.body = contents.encode()
         request.handler = None
 
@@ -521,7 +521,7 @@ class WebInterface(object):
         if not self.in_authorized_mode():
             raise cherrypy.HTTPError(401, "unauthorized")
         user_dto = UserDTO(username=username,
-                           role=User.UserRoles.ADMIN,
+                           role=User.UserRoles.SUPER,
                            accepted_terms=0)
         user_dto.set_password(password)
         self._user_controller.save_user(user_dto)

--- a/testing/unittests/gateway_tests/webservice_test.py
+++ b/testing/unittests/gateway_tests/webservice_test.py
@@ -108,7 +108,7 @@ class WebInterfaceTest(unittest.TestCase):
     def test_create_user(self):
         to_save_user = UserDTO(
             username='test',
-            role='ADMIN',
+            role='SUPER',
             pin_code=None
         )
         to_save_user.set_password('test')


### PR DESCRIPTION
    Perform POST request: https://localhost:8443/api/v1/authenticate/pin_code  body: b'{"code":"7785"}'
      => Response body: [200]
        {
            "user_id": 25,
            "user_role": "USER",
            "token": "146d4569f4ab41fc8ae1a0dd7403110e",
            "login_method": "pin_code"
        }
    
    --------------------------------------------
     => logged in and received token: 146d4569f4ab41fc8ae1a0dd7403110e
    --------------------------------------------
    Perform request:
      url: https://localhost:8443/get_modules_information,
      method: get,
      headers:
        Authorization: Bearer 146d4569f4ab41fc8ae1a0dd7403110e
      params:
      body: None
    
    Response:
      code: 401,
      headers:
        Content-Type: application/json
        Server: CherryPy/17.4.2
        Date: Thu, 05 Aug 2021 12:23:39 GMT
        Content-Length: 97
      body:
        {
            "success": false,
            "msg": "invalid_token",
            "detail": "User is non SUPER, need SUPER to access V0 api"
        }
    
    --------------------------------------------