### PR TITLE
setup system timezone in scheduler

### DIFF
--- a/src/gateway/scheduling_controller.py
+++ b/src/gateway/scheduling_controller.py
@@ -42,6 +42,7 @@ if False:  # MYPY
     from gateway.dto import LegacyScheduleDTO, LegacyStartupActionDTO
     from gateway.group_action_controller import GroupActionController
     from gateway.hal.master_controller import MasterController
+    from gateway.system_controller import SystemController
     from gateway.webservice import WebInterface
 
 logging.getLogger('apscheduler').setLevel(logging.WARNING)
@@ -73,14 +74,15 @@ class SchedulingController(object):
     NO_NTP_LOWER_LIMIT = 1546300800.0  # 2019-01-01
 
     @Inject
-    def __init__(self, group_action_controller=INJECTED, master_controller=INJECTED):
-        # type: (GroupActionController, MasterController) -> None
+    def __init__(self, group_action_controller=INJECTED, master_controller=INJECTED, system_controller=INJECTED):
+        # type: (GroupActionController, MasterController, SystemController) -> None
         self._group_action_controller = group_action_controller
         self._master_controller = master_controller
         self._web_interface = None  # type: Optional[WebInterface]
         self._schedules = {}  # type: Dict[int, ScheduleDTO]
         self._jobs = {}  # type: Dict[str, Job]
-        self._scheduler = BackgroundScheduler(job_defaults={
+        timezone = system_controller.get_timezone()
+        self._scheduler = BackgroundScheduler(timezone=timezone, job_defaults={
             'coalesce': True,
             'misfire_grace_time': 3600  # 1h
         })

--- a/src/gateway/system_controller.py
+++ b/src/gateway/system_controller.py
@@ -17,19 +17,22 @@ System BLL
 """
 from __future__ import absolute_import
 
-import os
-import logging
-import constants
 import glob
-import sqlite3
+import logging
+import os
 import shutil
-import tempfile
+import sqlite3
 import subprocess
+import tempfile
+import time
 from threading import Timer
+
 from six.moves.configparser import ConfigParser
-from ioc import Injectable, Singleton, Inject, INJECTED
-from platform_utils import System
+
+import constants
 from gateway.base_controller import BaseController
+from ioc import INJECTED, Inject, Injectable, Singleton
+from platform_utils import System
 
 if False:  # MYPY
     from typing import Dict, Any, List, Optional, Iterable
@@ -60,18 +63,7 @@ class SystemController(BaseController):
         os.symlink(timezone_file_path, constants.get_timezone_file())
 
     def get_timezone(self):
-        try:
-            path = os.path.realpath(constants.get_timezone_file())
-            if not path.startswith('/usr/share/zoneinfo/'):
-                # Reset timezone to default setting
-                self.set_timezone('UTC')
-                return 'UTC'
-            if path.startswith('/usr/share/zoneinfo/posix'):
-                # As seen on the buildroot os, the timezone info is all located in the posix folder within zoneinfo.
-                return path[26:]
-            return path[20:]
-        except Exception:
-            return 'UTC'
+        return time.tzname[0]
 
     def get_main_version(self):
         _ = self

--- a/testing/unittests/gateway_tests/scheduling_test.py
+++ b/testing/unittests/gateway_tests/scheduling_test.py
@@ -27,15 +27,20 @@ from peewee import SqliteDatabase
 
 from gateway.dto import ScheduleDTO
 from gateway.group_action_controller import GroupActionController
+from gateway.hal.master_controller import MasterController
+from gateway.maintenance_controller import MaintenanceController
 from gateway.models import Schedule
+from gateway.module_controller import ModuleController
+from gateway.pubsub import PubSub
 from gateway.scheduling_controller import SchedulingController
+from gateway.system_controller import SystemController
 from gateway.ventilation_controller import VentilationController
 from gateway.webservice import WebInterface
 from ioc import SetTestMode, SetUpTestInjections
 
 MODELS = [Schedule]
 
-
+MasterController
 class SchedulingControllerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -47,16 +52,16 @@ class SchedulingControllerTest(unittest.TestCase):
         self.test_db.connect()
         self.test_db.create_tables(MODELS)
 
-        system_controller = Mock()
-        system_controller.get_timezone.return_value = 'UTC'
-
         self.group_action_controller = Mock(GroupActionController)
         self.group_action_controller.do_group_action.return_value = {}
         self.group_action_controller.do_basic_action.return_value = {}
 
-        SetUpTestInjections(system_controller=system_controller,
-                            user_controller=None,
-                            maintenance_controller=None,
+        SetUpTestInjections(pubsub=Mock(PubSub),
+                            maintenance_controller=Mock(MaintenanceController),
+                            master_controller=Mock(MasterController),
+                            module_controller=Mock(ModuleController))
+        SetUpTestInjections(system_controller=SystemController())
+        SetUpTestInjections(user_controller=None,
                             message_client=None,
                             configuration_controller=None,
                             thermostat_controller=None,
@@ -69,10 +74,8 @@ class SchedulingControllerTest(unittest.TestCase):
                             pulse_counter_controller=Mock(),
                             frontpanel_controller=Mock(),
                             group_action_controller=self.group_action_controller,
-                            module_controller=Mock(),
                             energy_module_controller=Mock(),
-                            uart_controller=Mock(),
-                            master_controller=Mock())
+                            uart_controller=Mock())
         self.controller = SchedulingController()
         SetUpTestInjections(scheduling_controller=self.controller)
         self.controller.set_webinterface(WebInterface())

--- a/testing/unittests/gateway_tests/scheduling_test.py
+++ b/testing/unittests/gateway_tests/scheduling_test.py
@@ -40,7 +40,6 @@ from ioc import SetTestMode, SetUpTestInjections
 
 MODELS = [Schedule]
 
-MasterController
 class SchedulingControllerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/testing/unittests/gateway_tests/thermostat/gateway/thermostat_controller_test.py
+++ b/testing/unittests/gateway_tests/thermostat/gateway/thermostat_controller_test.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 import logging
 import unittest
 
-import mock
+from mock import Mock
 from peewee import SqliteDatabase
 
 import fakesleep
@@ -27,6 +27,7 @@ from gateway.models import DaySchedule, Output, OutputToThermostatGroup, \
     Preset, Pump, PumpToValve, Sensor, Thermostat, ThermostatGroup, Valve, \
     ValveToThermostat
 from gateway.output_controller import OutputController
+from gateway.pubsub import PubSub
 from gateway.sensor_controller import SensorController
 from gateway.system_controller import SystemController
 from gateway.thermostat.gateway.thermostat_controller_gateway import \
@@ -57,16 +58,14 @@ class ThermostatControllerTest(unittest.TestCase):
         self.test_db.bind(MODELS)
         self.test_db.connect()
         self.test_db.create_tables(MODELS)
-        system_controller = mock.Mock(SystemController)
-        system_controller.get_timezone.return_value = 'Europe/Brussels'
-        output_controller = mock.Mock(OutputController)
+        output_controller = Mock(OutputController)
         output_controller.get_output_status.return_value = OutputStatusDTO(id=0, status=False)
-        sensor_controller = mock.Mock(SensorController)
+        sensor_controller = Mock(SensorController)
         sensor_controller.get_sensor_status.side_effect = lambda x: SensorStatusDTO(id=x, value=10.0)
-        SetUpTestInjections(output_controller=output_controller,
-                            system_controller=system_controller,
+        SetUpTestInjections(pubsub=Mock(PubSub),
+                            output_controller=output_controller,
                             sensor_controller=sensor_controller,
-                            pubsub=mock.Mock())
+                            system_controller=SystemController())
         self._thermostat_controller = ThermostatControllerGateway()
         SetUpTestInjections(thermostat_controller=self._thermostat_controller)
         sensor = Sensor.create(source='master', external_id='1', physical_quantity='temperature', name='')


### PR DESCRIPTION
The apscheduler library performs validation for the timezone configuration.

    ValueError: Timezone offset does not match system offset: 0 != 7200. Please, check your config files