### PR TITLE
OM-2428 increase expire time for sensor statuses

### DIFF
--- a/src/gateway/sensor_controller.py
+++ b/src/gateway/sensor_controller.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 @Singleton
 class SensorController(BaseController):
     SYNC_STRUCTURES = [SyncStructure(Sensor, 'sensor')]
-    STATUS_EXIPRE = 60.0
+    STATUS_EXIPRE = 360.0
 
     MASTER_TYPES = {MasterEvent.SensorType.TEMPERATURE: Sensor.PhysicalQuantities.TEMPERATURE,
                     MasterEvent.SensorType.HUMIDITY: Sensor.PhysicalQuantities.HUMIDITY,


### PR DESCRIPTION
The core controller only refreshes sensor values every 5m since update
events are implemented in the firmware there.