### PR TITLE
Bugfix/cloud link bugfixes

### DIFF
--- a/src/esafe/rebus/dummy_rebus_devices.json
+++ b/src/esafe/rebus/dummy_rebus_devices.json
@@ -11,27 +11,51 @@
       "initial_state": "closed"
     },
     {
+      "id": 144,
+      "type": "parcelbox",
+      "initial_state": "closed",
+      "height": 100,
+      "width": 380,
+      "size": "XS"
+    },
+    {
       "id": 64,
       "type": "parcelbox",
       "initial_state": "closed",
-      "height": 700,
-      "width": 400,
+      "height": 200,
+      "width": 380,
       "size": "S"
     },
     {
       "id": 80,
       "type": "parcelbox",
       "initial_state": "closed",
-      "height": 300,
-      "width": 400,
+      "height": 400,
+      "width": 380,
       "size": "M"
+    },
+    {
+      "id": 160,
+      "type": "parcelbox",
+      "initial_state": "closed",
+      "height": 400,
+      "width": 760,
+      "size": "L1"
+    },
+    {
+      "id": 176,
+      "type": "parcelbox",
+      "initial_state": "closed",
+      "height": 760,
+      "width": 400,
+      "size": "L2"
     },
     {
       "id": 128,
       "type": "parcelbox",
       "initial_state": "closed",
-      "height": 300,
-      "width": 200,
+      "height": 800,
+      "width": 760,
       "size": "XL"
     },
     {

--- a/src/gateway/api/V1/deliveries.py
+++ b/src/gateway/api/V1/deliveries.py
@@ -95,8 +95,8 @@ class Deliveries(RestAPIEndpoint):
 
     @openmotics_api_v1(auth=True, pass_token=True,
                        check={'user_id': int, 'before_id': int, 'pagesize': int}, check_for_missing=False)
-    def get_delivery_history(self, user_id, auth_token, before_id=0, pagesize=100):
-        # type: (int, AuthenticationToken, int, int) -> ApiResponse
+    def get_delivery_history(self, auth_token, before_id=None, pagesize=100, user_id=None):
+        # type: (AuthenticationToken, int, int, int) -> ApiResponse
         deliveries = self.delivery_controller.load_deliveries(user_id=user_id, history=True, before_id=before_id, limit=pagesize)
         # filter the deliveries for only the user id when they are not technician or admin
         if auth_token.user.role not in [User.UserRoles.ADMIN, User.UserRoles.TECHNICIAN, User.UserRoles.SUPER]:

--- a/src/gateway/api/V1/parcelbox.py
+++ b/src/gateway/api/V1/parcelbox.py
@@ -78,6 +78,8 @@ class ParcelBox(RestAPIEndpoint):
                 delivery = deliveries[0] if len(deliveries) == 1 else None
                 if delivery is not None:
                     box['delivery'] = DeliverySerializer.serialize(delivery)
+                else:
+                    box['delivery'] = None
         return ApiResponse(body=boxes_serial)
 
     @openmotics_api_v1(auth=False, expect_body_type=None, check={'rebus_id': int})

--- a/src/gateway/api/V1/users.py
+++ b/src/gateway/api/V1/users.py
@@ -195,7 +195,7 @@ class Users(RestAPIEndpoint):
         user_dto_orig = self.user_controller.load_user(user_id, clear_password=False)
         user_dto = UserSerializer.deserialize(user_json)
         # only allow a subset of fields to be altered
-        for field in ['first_name', 'last_name', 'pin_code', 'language', 'apartment', 'email']:
+        for field in ['first_name', 'last_name', 'pin_code', 'language', 'apartment', 'email', 'is_active']:
             if field in user_dto.loaded_fields:
                 setattr(user_dto_orig, field, getattr(user_dto, field))
         saved_user = self.user_controller.save_user(user_dto_orig)

--- a/src/gateway/api/V1/webservice/webservice.py
+++ b/src/gateway/api/V1/webservice/webservice.py
@@ -166,6 +166,10 @@ def authentication_handler_v1(pass_token=False, pass_role=False, auth=False, aut
         check_token = auth_controller.check_token
         checked_token = check_token(token)  # type: Optional[AuthenticationToken]
 
+        if token is not None and checked_token is None:
+            raise UnAuthorizedException('The passed authentication token is invalid')
+
+
         # check the security level for this call
         if auth:
             if checked_token is None:

--- a/src/gateway/api/serializers/user.py
+++ b/src/gateway/api/serializers/user.py
@@ -35,15 +35,14 @@ logger = logging.getLogger(__name__)
 
 class UserSerializer(object):
     @staticmethod
-    def serialize(dto_object, fields=None):
-        # type: (UserDTO, Optional[List[str]]) -> Dict[str,Any]
+    def serialize(dto_object, fields=None, show_pin_code=False):
+        # type: (UserDTO, Optional[List[str]], bool) -> Dict[str,Any]
         data = {'id': dto_object.id,
                 'username': dto_object.username,
                 'first_name': dto_object.first_name,
                 'last_name': dto_object.last_name,
                 'role': dto_object.role,
                 'language': dto_object.language,
-                # 'pin_code': dto_object.pin_code,  # Hide the pin code for the api
                 'apartment': None,
                 'is_active': dto_object.is_active,
                 'accepted_terms': dto_object.accepted_terms,
@@ -51,6 +50,8 @@ class UserSerializer(object):
         if 'apartment' in dto_object.loaded_fields and isinstance(dto_object.apartment, ApartmentDTO):
             apartment_data = ApartmentSerializer.serialize(dto_object.apartment)
             data['apartment'] = apartment_data
+        if show_pin_code:
+            data['pin_code'] = dto_object.pin_code
         return SerializerToolbox.filter_fields(data, fields)
 
     @staticmethod

--- a/src/gateway/delivery_controller.py
+++ b/src/gateway/delivery_controller.py
@@ -78,7 +78,8 @@ class DeliveryController(object):
         if delivery_type is not None:
             query = query.where(Delivery.type == delivery_type)
         # filter on picked up when needed
-        query = query.where(Delivery.timestamp_pickup.is_null(not history))
+        if history is False:
+            query = query.where(Delivery.timestamp_pickup.is_null(True))
 
         # add the from_id
         if before_id is not None:

--- a/src/gateway/webservice.py
+++ b/src/gateway/webservice.py
@@ -670,6 +670,7 @@ class WebInterface(object):
             'websocket_maintenance',  # Maintenance over websockets
             'shutter_positions',  # Shutter positions
             'ventilation',
+            'v1_api'
         ]
 
         master_version = self._module_controller.get_master_version()

--- a/testing/unittests/gateway_tests/delivery_test.py
+++ b/testing/unittests/gateway_tests/delivery_test.py
@@ -379,8 +379,7 @@ class DeliveryControllerTest(unittest.TestCase):
         self.assertEqual(2, len(result))
 
         result = self.controller.load_deliveries(history=True)
-        # only two deliveries should be returned since the first one is already picked up
-        self.assertEqual(1, len(result))
+        self.assertEqual(3, len(result))
 
         result = self.controller.load_deliveries_filter(include_picked_up=True)
         self.assertEqual(3, len(result))


### PR DESCRIPTION
Various small bugfixes discovered during linking cloud to the eSafe version of the gateway.
 - Adding more dummy eSafe parcelboxes for testing purposes
 - Show the pin code for the user when requested with the correct authentication
 - return a 401 status when an invalid auth token is passed, instead of handling the call without any authentication
 - make the is_active field editable with the user put call
 - when requesting the parcel history, also include the non picked up packages
 - add the v1_api to the features list