### PR TITLE
Add esafe to the featurelist if applicable and add a ESAFE_DUMMY type…

### DIFF
--- a/src/gateway/initialize.py
+++ b/src/gateway/initialize.py
@@ -283,7 +283,7 @@ def setup_target_platform(target_platform, message_client_name):
     if controller_serial_port:
         Injectable.value(controller_serial=Serial(controller_serial_port, 115200, exclusive=True))
 
-    if target_platform in [Platform.Type.DUMMY, Platform.Type.ESAFE]:
+    if target_platform in Platform.DummyTypes + Platform.EsafeTypes:
         Injectable.value(maintenance_communicator=None)
         Injectable.value(passthrough_service=None)
         Injectable.value(master_controller=MasterDummyController())
@@ -330,7 +330,7 @@ def setup_target_platform(target_platform, message_client_name):
     else:
         logger.warning('Unhandled master implementation for %s', target_platform)
 
-    if target_platform in [Platform.Type.DUMMY, Platform.Type.ESAFE]:
+    if target_platform in Platform.DummyTypes + Platform.EsafeTypes:
         Injectable.value(frontpanel_controller=None)
     elif target_platform in Platform.CoreTypes:
         Injectable.value(frontpanel_controller=FrontpanelCoreController())
@@ -343,7 +343,7 @@ def setup_target_platform(target_platform, message_client_name):
     if target_platform == Platform.Type.ESAFE and six.PY3:
         from esafe.rebus.rebus_controller import RebusController
         Injectable.value(rebus_controller=RebusController())
-    elif target_platform == Platform.Type.DUMMY:
+    elif target_platform == Platform.Type.ESAFE_DUMMY:
         from esafe.rebus.dummy_rebus_controller import DummyRebusController
         Injectable.value(rebus_controller=DummyRebusController())
     else:

--- a/src/gateway/webservice.py
+++ b/src/gateway/webservice.py
@@ -71,6 +71,7 @@ from toolbox import Toolbox
 if False:  # MYPY
     from typing import Dict, Optional, Any, List, Literal, Union
     from bus.om_bus_client import MessageClient
+    from esafe.rebus.rebus_controller import RebusController
     from gateway.energy_module_controller import EnergyModuleController
     from gateway.group_action_controller import GroupActionController
     from gateway.hal.frontpanel_controller import FrontpanelController
@@ -354,7 +355,8 @@ class WebInterface(object):
                  room_controller=INJECTED, input_controller=INJECTED, sensor_controller=INJECTED,
                  pulse_counter_controller=INJECTED, group_action_controller=INJECTED,
                  frontpanel_controller=INJECTED, module_controller=INJECTED, ventilation_controller=INJECTED,
-                 uart_controller=INJECTED, system_controller=INJECTED, energy_module_controller=INJECTED):
+                 uart_controller=INJECTED, system_controller=INJECTED, energy_module_controller=INJECTED,
+                 rebus_controller=INJECTED):
         """
         Constructor for the WebInterface.
         """
@@ -380,6 +382,8 @@ class WebInterface(object):
         self._plugin_controller = None  # type: Optional[PluginController]
         self._metrics_collector = None  # type: Optional[MetricsCollector]
         self._metrics_controller = None  # type: Optional[MetricsController]
+
+        self._rebus_controller = rebus_controller  # type: Optional[RebusController]
 
         self._ws_metrics_registered = False
         self._energy_dirty = False
@@ -670,7 +674,6 @@ class WebInterface(object):
             'websocket_maintenance',  # Maintenance over websockets
             'shutter_positions',  # Shutter positions
             'ventilation',
-            'v1_api'
         ]
 
         master_version = self._module_controller.get_master_version()
@@ -685,6 +688,9 @@ class WebInterface(object):
             feature = Feature.get_or_none(name=name)
             if feature and feature.enabled:
                 features.append(name)
+
+        if self._rebus_controller is not None:
+            features.append('esafe')
 
         return {'features': features}
 

--- a/src/platform_utils.py
+++ b/src/platform_utils.py
@@ -380,16 +380,17 @@ class Platform(object):
 
     class Type(object):
         DUMMY = 'DUMMY'
+        ESAFE_DUMMY = 'ESAFE_DUMMY'
         CLASSIC = 'CLASSIC'
         CORE_PLUS = 'CORE_PLUS'
         CORE = 'CORE'
         ESAFE = 'ESAFE'
 
-    AnyTypes = [Type.DUMMY]
+    DummyTypes = [Type.DUMMY, Type.ESAFE_DUMMY]
     ClassicTypes = [Type.CLASSIC]
     CoreTypes = [Type.CORE, Type.CORE_PLUS]
     EsafeTypes = [Type.ESAFE]
-    Types = AnyTypes + ClassicTypes + CoreTypes + EsafeTypes
+    Types = DummyTypes + ClassicTypes + CoreTypes + EsafeTypes
 
     @staticmethod
     def get_platform():

--- a/testing/unittests/gateway_tests/scheduling_test.py
+++ b/testing/unittests/gateway_tests/scheduling_test.py
@@ -74,7 +74,8 @@ class SchedulingControllerTest(unittest.TestCase):
                             frontpanel_controller=Mock(),
                             group_action_controller=self.group_action_controller,
                             energy_module_controller=Mock(),
-                            uart_controller=Mock())
+                            uart_controller=Mock(),
+                            rebus_controller=None)
         self.controller = SchedulingController()
         SetUpTestInjections(scheduling_controller=self.controller)
         self.controller.set_webinterface(WebInterface())

--- a/testing/unittests/gateway_tests/webservice_test.py
+++ b/testing/unittests/gateway_tests/webservice_test.py
@@ -76,7 +76,8 @@ class WebInterfaceTest(unittest.TestCase):
                             ventilation_controller=self.ventilation_controller,
                             module_controller=self.module_controller,
                             energy_module_controller=self.energy_module_controller,
-                            uart_controller=mock.Mock())
+                            uart_controller=mock.Mock(),
+                            rebus_controller=None)
         self.web = WebInterface()
 
     def test_get_usernames(self):


### PR DESCRIPTION
… for the config file

 - Addition of the esafe feature string when an rebus controller is detected (dummy or real one)
 - Addition of the ESAFE_DUMMY platform to load in the rebus controller when this is required, Not when the platform DUMMY is enabled