### PR TITLE
fix rooms migration

### DIFF
--- a/src/gateway/migrations/orm/021_remove_floors.py
+++ b/src/gateway/migrations/orm/021_remove_floors.py
@@ -30,7 +30,7 @@ def migrate(migrator, database, fake=False, **kwargs):
     class BaseModel(Model):
         class Meta:
             database = SqliteDatabase(constants.get_gateway_database_file(),
-                                      pragmas={'foreign_keys': 1})
+                                      pragmas={'foreign_keys': 0})
 
     class Floor(BaseModel):
         id = AutoField()


### PR DESCRIPTION
Disables foreignkey checking during while removing the Floors model.
This ensures the room_id references don't get set to NULL while the
migration is (re)creating the table.