### PR TITLE
wait longer before attempting to rollback openvpn

### DIFF
--- a/src/vpn_service.py
+++ b/src/vpn_service.py
@@ -733,7 +733,7 @@ class OpenVPNTask(object):
                 # Only attempt rollbacks when cloud is accessible
                 if self.open:
                     self.connect_retries = 0
-                elif self.connect_retries < 5:
+                elif self.connect_retries < 32:
                     logger.info('Waiting for VPN connection...')
                     self.connect_retries += 1
                 else:

--- a/testing/unittests/vpn_service_test.py
+++ b/testing/unittests/vpn_service_test.py
@@ -331,7 +331,7 @@ class VPNServiceTest(TestCase):
              mock.patch.object(Util, 'stop_vpn') as stop_vpn:
             # Attempt rollback
             context = {'cloud_enabled': True, 'heartbeat_success': True, 'connectivity_success': True, 'open_vpn': True}
-            task.connect_retries = 10
+            task.connect_retries = 50
             self.assertEqual(list(task.run(context)), [('VPN_OPEN', True)])
             activate.assert_called_with(rollback=True)
 


### PR DESCRIPTION
When a gateway is disconnected from the network it takes a while before
the vpn tunnel is back up.