### PR TITLE
BE-111 delete unreferenced pumps during thermostat sync

### DIFF
--- a/src/gateway/models.py
+++ b/src/gateway/models.py
@@ -367,7 +367,7 @@ class Pump(BaseModel):
     def cooling_valves(self):  # type: () -> List[Valve]
         return self._valves(mode=ThermostatGroup.Modes.COOLING)
 
-    def _valves(self, mode):
+    def _valves(self, mode):  # type: (str) -> List[Valve]
         return [valve for valve in Valve.select(Valve, ValveToThermostat.mode, ValveToThermostat.priority)
                                         .distinct()
                                         .join_from(Valve, ValveToThermostat)

--- a/src/gateway/models.pyi
+++ b/src/gateway/models.pyi
@@ -284,7 +284,7 @@ class OutputToThermostatGroup(BaseModel):
 class Pump(BaseModel):
     id: MixedPrimaryKeyField
     name: MixedCharField
-    output: Optional[OutputForeignKeyField]
+    output: Output
 
     @property
     def valves(self) -> List[Valve]: ...
@@ -294,8 +294,6 @@ class Pump(BaseModel):
 
     @property
     def cooling_valves(self) -> List[Valve]: ...
-
-    def _valves(self, mode: str) -> List[Valve]: ...
 
 
 class PumpForeignKeyField(Pump, ForeignKeyField): ...

--- a/src/gateway/thermostat/gateway/thermostat_controller_gateway.py
+++ b/src/gateway/thermostat/gateway/thermostat_controller_gateway.py
@@ -121,6 +121,9 @@ class ThermostatControllerGateway(ThermostatController):
             thermostat_pid.update_thermostat(thermostat)
             thermostat_pid.tick()
             # TODO: Delete stale/removed thermostats
+        # FIXME: remove invalid pumps, database should cascade instead.
+        Pump.delete().where(Pump.output.is_null()) \
+            .execute()
         self._sync_scheduler()
 
     def _update_pumps(self):  # type: () -> None
@@ -575,7 +578,7 @@ class ThermostatControllerGateway(ThermostatController):
             .execute()
 
     def load_heating_pump_group(self, pump_group_id):  # type: (int) -> PumpGroupDTO
-        pump = Pump.get(number=pump_group_id)
+        pump = Pump.get(number=pump_group_id) # type: Pump
         return PumpGroupDTO(id=pump_group_id,
                             pump_output_id=pump.output.number,
                             valve_output_ids=[valve.output.number for valve in pump.heating_valves])


### PR DESCRIPTION
The ORM currently uses set null for the output relation on pumps,
instead of cascading which results in potentially invalid entries.