### PR TITLE
BE-130 Added can_bus_termination_toggle feature for gen3

### DIFF
--- a/src/gateway/webservice.py
+++ b/src/gateway/webservice.py
@@ -701,6 +701,9 @@ class WebInterface(object):
         if master_version >= (3, 143, 88):
             features.append('input_states')
 
+        if Platform.get_platform() in Platform.CoreTypes:
+            features.append('can_bus_termination_toggle')
+
         feature = Feature.get_or_none(name=Feature.THERMOSTATS_GATEWAY)
         if feature and feature.enabled:
             features.extend([Feature.THERMOSTATS_GATEWAY, 'thermostat_groups'])


### PR DESCRIPTION
```
In [9]: Platform.get_platform()
Out[9]: 'CLASSIC'

In [10]: Platform.get_platform() in Platform.ClassicTypes
Out[10]: True

In [11]: Platform.get_platform() in Platform.CoreTypes
Out[11]: False
```
https://www.openmotics.com/wp-content/uploads/2021/06/Datasheet_Brain-module-1.pdf