### PR TITLE
BE-131 Gateway thermostat feature on gen3

### DIFF
--- a/src/gateway/hal/master_controller.py
+++ b/src/gateway/hal/master_controller.py
@@ -27,7 +27,7 @@ from gateway.dto import DimmerConfigurationDTO, GlobalFeedbackDTO, \
 
 
 if False:  # MYPY
-    from typing import Any, Dict, List, Literal, Optional, Tuple
+    from typing import Any, Dict, List, Literal, Optional, Tuple, Set
     from master.core.basic_action import BasicAction
 
     HEALTH = Literal['success', 'unstable', 'failure']

--- a/src/gateway/hal/master_controller.py
+++ b/src/gateway/hal/master_controller.py
@@ -55,6 +55,9 @@ class MasterController(object):
     # Public API #
     ##############
 
+    def get_features(self):  # type: () -> Set[str]
+        raise NotImplementedError()
+
     def get_command_histograms(self):
         return self._master_communicator.get_command_histograms()
 

--- a/src/gateway/hal/master_controller_classic.py
+++ b/src/gateway/hal/master_controller_classic.py
@@ -125,15 +125,7 @@ class MasterClassicController(MasterController):
         self._module_log_lock = Lock()
 
     def get_features(self):  # type: () -> Set[str]
-        features = set()
-        if self._master_version is not None:
-            if self._master_version >= (3, 143, 77):
-                features.add('default_timer_disabled')
-            if self._master_version >= (3, 143, 79):
-                features.add('100_steps_dimmer')
-            if self._master_version >= (3, 143, 88):
-                features.add('input_states')
-        return features
+        return set()
 
     #################
     # Private stuff #

--- a/src/gateway/hal/master_controller_classic.py
+++ b/src/gateway/hal/master_controller_classic.py
@@ -65,7 +65,7 @@ from serial_utils import CommunicationTimedOutException
 from logs import Logs
 
 if False:  # MYPY
-    from typing import Any, Dict, List, Literal, Optional, Tuple
+    from typing import Any, Dict, List, Literal, Optional, Tuple, Set
     from serial import Serial
 
     HEALTH = Literal['success', 'unstable', 'failure']

--- a/src/gateway/hal/master_controller_classic.py
+++ b/src/gateway/hal/master_controller_classic.py
@@ -124,6 +124,17 @@ class MasterClassicController(MasterController):
         )
         self._module_log_lock = Lock()
 
+    def get_features(self):  # type: () -> Set[str]
+        features = set()
+        if self._master_version is not None:
+            if self._master_version >= (3, 143, 77):
+                features.add('default_timer_disabled')
+            if self._master_version >= (3, 143, 79):
+                features.add('100_steps_dimmer')
+            if self._master_version >= (3, 143, 88):
+                features.add('input_states')
+        return features
+
     #################
     # Private stuff #
     #################

--- a/src/gateway/hal/master_controller_core.py
+++ b/src/gateway/hal/master_controller_core.py
@@ -62,7 +62,7 @@ from platform_utils import Hardware
 from logs import Logs
 
 if False:  # MYPY
-    from typing import Any, Dict, List, Literal, Tuple, Optional, Type, Union, TypeVar
+    from typing import Any, Dict, List, Literal, Tuple, Optional, Type, Union, TypeVar, Set
     from master.core.core_updater import CoreUpdater
     T_co = TypeVar('T_co', bound=None, covariant=True)
     HEALTH = Literal['success', 'unstable', 'failure']

--- a/src/gateway/hal/master_controller_core.py
+++ b/src/gateway/hal/master_controller_core.py
@@ -125,6 +125,9 @@ class MasterCoreController(MasterController):
             BackgroundConsumer(CoreAPI.module_added(), 0, self._handle_new_module)
         )
 
+    def get_features(self):  # type: () -> Set[str]
+        return {'can_bus_termination_toggle'}
+
     #################
     # Private stuff #
     #################

--- a/src/gateway/hal/master_controller_core.py
+++ b/src/gateway/hal/master_controller_core.py
@@ -500,7 +500,7 @@ class MasterCoreController(MasterController):
     def get_firmware_version(self):
         version = self._master_communicator.do_command(command=CoreAPI.get_firmware_version(),
                                                        fields={})['version']
-        return tuple(version.split('.'))
+        return tuple([int(x) for x in version.split('.')])
 
     def sync_time(self):
         # type: () -> None

--- a/src/gateway/hal/master_controller_dummy.py
+++ b/src/gateway/hal/master_controller_dummy.py
@@ -72,6 +72,9 @@ class MasterDummyController(MasterController):
         super(MasterDummyController, self).__init__(MasterCommunicator())
         self._eeprom_controller = DummyEepromObject()
 
+    def get_features(self):  # type: () -> Set[str]
+        return set()
+
     def get_master_online(self):  # type: () -> bool
         return True
 

--- a/src/gateway/hal/master_controller_dummy.py
+++ b/src/gateway/hal/master_controller_dummy.py
@@ -27,7 +27,7 @@ from gateway.exceptions import UnsupportedException
 from gateway.hal.master_controller import MasterController
 
 if False:  # MYPY
-    from typing import Any, Dict, List, Literal, Optional, Tuple
+    from typing import Any, Dict, List, Literal, Optional, Tuple, Set
     from plugins.base import PluginController
 
 logger = logging.getLogger(__name__)

--- a/src/gateway/module_controller.py
+++ b/src/gateway/module_controller.py
@@ -28,7 +28,7 @@ from gateway.models import Module, Sensor
 from gateway.mappers.module import ModuleMapper
 
 if False:  # MYPY
-    from typing import Dict, List, Optional, Any
+    from typing import Dict, List, Optional, Any, Set
     from gateway.hal.master_controller import MasterController
     from gateway.energy_module_controller import EnergyModuleController
 
@@ -233,6 +233,9 @@ class ModuleController(BaseController):
 
     def master_clear_error_list(self):
         return self._master_controller.clear_error_list()
+
+    def master_get_features(self):  # type: () -> Set[str]
+        return self.master_controller.get_features()
 
     def get_configuration_dirty_flag(self):
         # type: () -> bool

--- a/src/gateway/module_controller.py
+++ b/src/gateway/module_controller.py
@@ -235,7 +235,7 @@ class ModuleController(BaseController):
         return self._master_controller.clear_error_list()
 
     def master_get_features(self):  # type: () -> Set[str]
-        return self.master_controller.get_features()
+        return self._master_controller.get_features()
 
     def get_configuration_dirty_flag(self):
         # type: () -> bool

--- a/src/gateway/thermostat/gateway/thermostat_controller_gateway.py
+++ b/src/gateway/thermostat/gateway/thermostat_controller_gateway.py
@@ -36,7 +36,7 @@ from gateway.thermostat.thermostat_controller import ThermostatController
 from ioc import INJECTED, Inject
 
 if False:  # MYPY
-    from typing import Dict, Iterable, List, Optional, Tuple
+    from typing import Dict, Iterable, List, Optional, Tuple, Set
     from gateway.output_controller import OutputController
     from gateway.sensor_controller import SensorController
 
@@ -67,6 +67,11 @@ class ThermostatControllerGateway(ThermostatController):
         self._sync_thread = None  # type: Optional[DaemonThread]
         self.thermostat_pids = {}  # type: Dict[int, ThermostatPid]
         self._pump_valve_controller = PumpValveController()
+
+    def get_features(self):
+        # type: () -> Set[str]
+        return {'thermostats_gateway',
+                'thermostat_groups'}
 
     def start(self):  # type: () -> None
         logger.info('Starting gateway thermostatcontroller...')

--- a/src/gateway/thermostat/master/thermostat_controller_master.py
+++ b/src/gateway/thermostat/master/thermostat_controller_master.py
@@ -35,7 +35,7 @@ from master.classic.master_communicator import CommunicationTimedOutException
 from toolbox import Toolbox
 
 if False:  # MYPY
-    from typing import Any, List, Dict, Optional, Tuple
+    from typing import Any, List, Dict, Optional, Tuple, Set
     from gateway.dto import OutputStatusDTO
     from gateway.hal.master_controller_classic import MasterClassicController
     from gateway.output_controller import OutputController
@@ -73,6 +73,10 @@ class ThermostatControllerMaster(ThermostatController):
         self._enabled = True
 
         self._pubsub.subscribe_master_events(PubSub.MasterTopics.EEPROM, self._handle_master_event)
+
+    def get_features(self):
+        # type: () -> Set[str]
+        return set()
 
     def start(self):
         # type: () -> None

--- a/src/gateway/thermostat/thermostat_controller.py
+++ b/src/gateway/thermostat/thermostat_controller.py
@@ -18,7 +18,7 @@ if False:  # MYPY
         ThermostatGroupStatusDTO, ThermostatGroupDTO, PumpGroupDTO, \
         RTD10DTO, GlobalRTD10DTO
     from gateway.output_controller import OutputController
-    from typing import List, Tuple, Optional
+    from typing import List, Tuple, Optional, Set
 
 
 class ThermostatController(object):
@@ -27,6 +27,9 @@ class ThermostatController(object):
     def __init__(self, output_controller):
         # type: (OutputController) -> None
         self._output_controller = output_controller
+
+    def get_features(self):  # type: () -> Set[str]
+        raise NotImplementedError()
 
     def start(self):  # type: () -> None
         raise NotImplementedError()

--- a/src/gateway/webservice.py
+++ b/src/gateway/webservice.py
@@ -691,6 +691,10 @@ class WebInterface(object):
             'ventilation',  # Native ventilation
             'modules_information',  # Clean module information
             'dynamic_updates',  # Dynamic updates
+            # TODO: remove
+            'default_timer_disabled',
+            '100_steps_dimmer',
+            'input_states'
         }
         features |= self._module_controller.master_get_features()
         features |= self._thermostat_controller.get_features()

--- a/src/gateway/webservice.py
+++ b/src/gateway/webservice.py
@@ -692,24 +692,8 @@ class WebInterface(object):
             'modules_information',  # Clean module information
             'dynamic_updates',  # Dynamic updates
         }
-
-        if Platform.get_platform() in Platform.CoreTypes:
-            features.add('can_bus_termination_toggle')
-
-        if Platform.get_platform() in Platform.ClassicTypes:
-            # TODO: cleanup
-            master_version = self._module_controller.get_master_version()
-            if master_version >= (3, 143, 77):
-                features.add('default_timer_disabled')
-            if master_version >= (3, 143, 79):
-                features.add('100_steps_dimmer')
-            if master_version >= (3, 143, 88):
-                features.add('input_states')
-
-        from gateway.thermostat.gateway.thermostat_controller_gateway import ThermostatControllerGateway
-        if isinstance(self._thermostat_controller, ThermostatControllerGateway):
-            features.add('thermostats_gateway')
-            features.add('thermostat_groups')
+        features |= self._module_controller.master_get_features()
+        features |= self._thermostat_controller.get_features()
 
         if self._rebus_controller is not None:
             features.add('esafe')

--- a/src/gateway/webservice.py
+++ b/src/gateway/webservice.py
@@ -59,7 +59,6 @@ from gateway.exceptions import CommunicationFailure, \
     WrongInputParametersException
 from gateway.mappers.thermostat import ThermostatMapper
 from gateway.models import Config, Database, Feature, Schedule, User, Module
-from gateway.thermostat.gateway.thermostat_controller_gateway import ThermostatControllerGateway
 from gateway.thermostat.thermostat_controller import ThermostatController
 from gateway.uart_controller import UARTController
 from gateway.websockets import EventsSocket, MaintenanceSocket, \
@@ -707,6 +706,7 @@ class WebInterface(object):
             if master_version >= (3, 143, 88):
                 features.add('input_states')
 
+        from gateway.thermostat.gateway.thermostat_controller_gateway import ThermostatControllerGateway
         if isinstance(self._thermostat_controller, ThermostatControllerGateway):
             features.add('thermostats_gateway')
             features.add('thermostat_groups')

--- a/src/gateway/webservice.py
+++ b/src/gateway/webservice.py
@@ -679,7 +679,7 @@ class WebInterface(object):
         """
         Returns all available features this Gateway supports. This allows to make flexible clients
         """
-        features = [
+        features = {
             'metrics',  # Advanced metrics (including metrics over websockets)
             'dirty_flag',  # A dirty flag that can be used to trigger syncs on power & master
             'scheduling',  # Gateway backed scheduling
@@ -691,27 +691,30 @@ class WebInterface(object):
             'ventilation',  # Native ventilation
             'modules_information',  # Clean module information
             'dynamic_updates',  # Dynamic updates
-        ]
-
-        master_version = self._module_controller.get_master_version()
-        if master_version >= (3, 143, 77):
-            features.append('default_timer_disabled')
-        if master_version >= (3, 143, 79):
-            features.append('100_steps_dimmer')
-        if master_version >= (3, 143, 88):
-            features.append('input_states')
+        }
 
         if Platform.get_platform() in Platform.CoreTypes:
-            features.append('can_bus_termination_toggle')
+            features.add('can_bus_termination_toggle')
+            features.add('thermostats_gateway')
+            features.add('thermostat_groups')
 
-        feature = Feature.get_or_none(name=Feature.THERMOSTATS_GATEWAY)
-        if feature and feature.enabled:
-            features.extend([Feature.THERMOSTATS_GATEWAY, 'thermostat_groups'])
+        if Platform.get_platform() in Platform.ClassicTypes:
+            master_version = self._module_controller.get_master_version()
+            if master_version >= (3, 143, 77):
+                features.add('default_timer_disabled')
+            if master_version >= (3, 143, 79):
+                features.add('100_steps_dimmer')
+            if master_version >= (3, 143, 88):
+                features.add('input_states')
+            feature = Feature.get_or_none(name=Feature.THERMOSTATS_GATEWAY)
+            if feature and feature.enabled:
+                features.add('thermostats_gateway')
+                features.add('thermostat_groups')
 
         if self._rebus_controller is not None:
-            features.append('esafe')
+            features.add('esafe')
 
-        return {'features': features}
+        return {'features': list(features)}
 
     @openmotics_api(auth=True)
     def get_platform_details(self):  # type: () -> Dict[str, str]

--- a/src/gateway/webservice.py
+++ b/src/gateway/webservice.py
@@ -59,6 +59,7 @@ from gateway.exceptions import CommunicationFailure, \
     WrongInputParametersException
 from gateway.mappers.thermostat import ThermostatMapper
 from gateway.models import Config, Database, Feature, Schedule, User, Module
+from gateway.thermostat.gateway.thermostat_controller_gateway import ThermostatControllerGateway
 from gateway.thermostat.thermostat_controller import ThermostatController
 from gateway.uart_controller import UARTController
 from gateway.websockets import EventsSocket, MaintenanceSocket, \
@@ -695,10 +696,9 @@ class WebInterface(object):
 
         if Platform.get_platform() in Platform.CoreTypes:
             features.add('can_bus_termination_toggle')
-            features.add('thermostats_gateway')
-            features.add('thermostat_groups')
 
         if Platform.get_platform() in Platform.ClassicTypes:
+            # TODO: cleanup
             master_version = self._module_controller.get_master_version()
             if master_version >= (3, 143, 77):
                 features.add('default_timer_disabled')
@@ -706,10 +706,10 @@ class WebInterface(object):
                 features.add('100_steps_dimmer')
             if master_version >= (3, 143, 88):
                 features.add('input_states')
-            feature = Feature.get_or_none(name=Feature.THERMOSTATS_GATEWAY)
-            if feature and feature.enabled:
-                features.add('thermostats_gateway')
-                features.add('thermostat_groups')
+
+        if isinstance(self._thermostat_controller, ThermostatControllerGateway):
+            features.add('thermostats_gateway')
+            features.add('thermostat_groups')
 
         if self._rebus_controller is not None:
             features.add('esafe')


### PR DESCRIPTION
Altered the get_features API to check which class instances are loaded, instead of the features table. This decision logic is already present in the initialize functions anyhow.