### PR TITLE
Better API access logging

### DIFF
--- a/src/logs.py
+++ b/src/logs.py
@@ -34,6 +34,7 @@ class Logs(object):
     LOG_FORMAT = "%(asctime)s - %(levelname)-8s - (%(threadName)s) - %(name)s - %(message)s"
     PREFIX = constants.OPENMOTICS_PREFIX  # e.g. /x
     UPDATE_LOGS_FOLDER = os.path.join(PREFIX, 'update_logs')  # e.g. /x/update_logs
+    WEBSERVICE_ACCESS_LOGGER = 'gateway.webservice.access'
 
     @staticmethod
     def setup_logger(log_level_override=None):
@@ -41,9 +42,6 @@ class Logs(object):
         Setup the OpenMotics logger.
         :param log_level_override: Sets the main log level for OpenMotics logging to the default StreamHandler/SysLogHandler
         """
-
-        from platform_utils import System
-
         # Remove all log handlers (since python2 `defaultConfig` has no `force` flag)
         root_logger = logging.getLogger()
         while root_logger.handlers:
@@ -66,6 +64,15 @@ class Logs(object):
         # Apply log level
         for namespace in Logs._get_service_namespaces():
             Logs.set_loglevel(openmotics_log_level, namespace)
+
+        # Add stdout logger for `gateway.webservice.access`
+        access_logger = logging.getLogger(Logs.WEBSERVICE_ACCESS_LOGGER)
+        while len(access_logger.handlers) > 0:
+            access_logger.removeHandler(access_logger.handlers[0])
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        stdout_handler.setFormatter(logging.Formatter(Logs.LOG_FORMAT))
+        access_logger.addHandler(stdout_handler)
+        access_logger.propagate = False
 
     @staticmethod
     def get_update_logger(name):  # type: (str) -> Logger
@@ -116,7 +123,8 @@ class Logs(object):
             if namespace is None or re.match("^{}.*".format(namespace), logger_namespace):
                 logger = logging.getLogger(logger_namespace)
                 logger.setLevel(level)
-                logger.propagate = True
+                if logger.name != Logs.WEBSERVICE_ACCESS_LOGGER:
+                    logger.propagate = True
 
     @staticmethod
     def _get_service_namespaces():

--- a/src/plugin_runtime/base.py
+++ b/src/plugin_runtime/base.py
@@ -271,13 +271,14 @@ class PluginWebResponse(object):
     """
     VARIABLES_TO_SERIALIZE = ['status_code', 'body', 'headers', 'path', 'version']
 
-    def __init__(self, status_code=None, body=None, headers=None, path=None, version=2):
-        # type: (Optional[int], Optional[Any], Optional[Dict[str, str]], Optional[str], int) -> None
+    def __init__(self, status_code=200, body=None, headers=None, path=None, version=2):
+        # type: (int, Optional[Any], Optional[Dict[str, str]], Optional[str], int) -> None
         self.status_code = status_code
         self.body = body
         self.headers = headers or {}
         self.path = path
         self.version = version
+
     def serialize(self):
         # type: () -> str
         obj_dict = {}
@@ -320,6 +321,7 @@ class PluginWebResponse(object):
         )
         return '<PluginWebResponse>   {}'.format(vars_str)
 
+
 class PluginWebRequest(object):
     """
     Class that will hold the data for an api request to the plugin
@@ -344,7 +346,6 @@ class PluginWebRequest(object):
             else:
                 obj_dict[var] = getattr(self, var)
         return json.dumps(obj_dict)
-
 
     @staticmethod
     def deserialize(serial_str):

--- a/src/plugin_runtime/runtime.py
+++ b/src/plugin_runtime/runtime.py
@@ -76,7 +76,8 @@ class PluginRuntime(object):
             http_port = int(config.get('OpenMotics', 'http_port'))
         except (NoSectionError, NoOptionError):
             http_port = 80
-        self._webinterface = WebInterfaceDispatcher(self._writer.log, port=http_port)
+        self._webinterface = WebInterfaceDispatcher(self._writer.log,
+                                                    port=http_port)
 
     def _init_plugin(self):
         # type: () -> None
@@ -98,7 +99,7 @@ class PluginRuntime(object):
         check_plugin(plugin_class)
 
         # Set the name, version, interfaces
-        self._name = plugin_class.name
+        self._name = self._webinterface.plugin_name = plugin_class.name
         self._version = plugin_class.version
         self._interfaces = plugin_class.interfaces
 

--- a/src/plugin_runtime/web.py
+++ b/src/plugin_runtime/web.py
@@ -44,6 +44,7 @@ class WebInterfaceDispatcher(object):
         self.__port = port
         self.__warned = False
         self.__available_calls = _load_webinterface()
+        self.plugin_name = None
 
     def __getattr__(self, attribute):
         if attribute in self.__available_calls:
@@ -83,7 +84,8 @@ class WebInterfaceDispatcher(object):
             try:
                 response = requests.get('http://{0}:{1}/{2}'.format(self.__hostname, self.__port, name),
                                         params=kwargs,
-                                        timeout=30.0)
+                                        timeout=30.0,
+                                        headers={'User-Agent': 'Plugin {0}'.format(self.plugin_name)})
                 return response.text
             except Exception:
                 return json.dumps({'success': False,

--- a/src/plugins/runner.py
+++ b/src/plugins/runner.py
@@ -14,10 +14,10 @@ from six.moves.queue import Empty, Full, Queue
 from gateway.daemon_thread import BaseThread
 from toolbox import PluginIPCReader, PluginIPCWriter
 from plugin_runtime.base import PluginWebRequest, PluginWebResponse
+from gateway.webservice import WebInterface, log_access
 
 if False:  # MYPY
     from typing import Any, Dict, Callable, List, Optional, AnyStr
-    from gateway.webservice import WebInterface
 
 logger_ = logging.getLogger(__name__)
 
@@ -62,6 +62,7 @@ class Service(object):
                 return self
         return None
 
+    @log_access
     @cherrypy.expose
     def index(self, method, plugin_web_request, *args, **kwargs):
         # type: (str, PluginWebRequest, Any, Any) -> Optional[AnyStr]


### PR DESCRIPTION
Example of the default - `INFO` level - logging:
```
2022-01-24 10:10:00,743 - INFO     - (CP Server Thread-62) - gateway.webservice.access - 10.37.0.1 - GET - /get_shutter_configurations - Status: 200 - Duration: 0.05s
2022-01-24 10:10:01,344 - INFO     - (CP Server Thread-63) - gateway.webservice.access - 10.37.0.1 - GET - /get_shutter_group_configurations - Status: 200 - Duration: 0.04s
2022-01-24 10:10:01,979 - INFO     - (CP Server Thread-64) - gateway.webservice.access - 10.37.0.1 - GET - /get_startup_action_configuration - Status: 200 - Duration: 0.01s
2022-01-24 10:10:02,561 - INFO     - (CP Server Thread-65) - gateway.webservice.access - 10.37.0.1 - GET - /get_features - Status: 200 - Duration: 0.00s
2022-01-24 10:10:03,087 - INFO     - (CP Server Thread-66) - gateway.webservice.access - 10.37.0.1 - GET - /get_thermostat_group_configurations - Status: 200 - Duration: 0.05s
2022-01-24 10:10:03,933 - INFO     - (CP Server Thread-67) - gateway.webservice.access - 10.37.0.1 - GET - /get_thermostat_configurations - Status: 200 - Duration: 0.29s
2022-01-24 10:10:03,978 - INFO     - (CP Server Thread-71) - gateway.webservice.access - 127.0.0.1 - GET - /set_loglevel - Status: 200 - Duration: 0.01s
```

If `DEBUG` level logging is enabled, a second logging statement will be logged before the call is processed with query parameters and the `User-Agent` and `X-Request-Id` headers. Example:
```
2022-01-24 11:02:58,273 - DEBUG    - (CP Server Thread-71) - gateway.webservice.access - 10.4.20.100 - GET - /get_plugins - Query parameters: {} - User-Agent: Mozilla/5.0 ... Chrome/100.0.4840.0 Safari/537.36
2022-01-24 11:02:58,309 - INFO     - (CP Server Thread-71) - gateway.webservice.access - 10.4.20.100 - GET - /get_plugins - Status: 200 - Duration: 0.04s
2022-01-24 11:03:39,586 - DEBUG    - (CP Server Thread-65) - gateway.webservice.access - 127.0.0.1 - GET - /set_loglevel - Query parameters: {"logger_name":"gateway.webservice.access","level":"DEBUG"} - User-Agent: PostmanRuntime/7.29.0
2022-01-24 11:03:39,598 - INFO     - (CP Server Thread-65) - gateway.webservice.access - 127.0.0.1 - GET - /set_loglevel - Status: 200 - Duration: 0.01s
2022-01-24 11:03:41,478 - DEBUG    - (CP Server Thread-65) - gateway.webservice.access - 127.0.0.1 - GET - /login - Query parameters: {"username":"admin","password":"***"} - User-Agent: PostmanRuntime/7.29.0
2022-01-24 11:03:41,524 - INFO     - (CP Server Thread-65) - gateway.webservice.access - 127.0.0.1 - GET - /login - Status: 200 - Duration: 0.05s
```

It is also possible to mask certain query parameters on a per-API basis; for example for passwords or other sensitive information. Note that in that case, the actual value will be replaced by `***` to make it clear that a value was passed, but it was masked.