### PR TITLE
metrics collector log stacktrace

### DIFF
--- a/src/gateway/metrics_controller.py
+++ b/src/gateway/metrics_controller.py
@@ -391,7 +391,7 @@ class MetricsController(object):
                 if self._throttled_down:
                     self._refresh_cloud_interval()
             except Exception as ex:
-                logger.error('Error sending metrics to Cloud: {0}'.format(ex))
+                logger.exception('Error sending metrics to Cloud: {0}'.format(ex))
                 if time_ago_send > 60 * 60:
                     # Decrease metrics rate, but at least every 2 hours
                     # Decrease cloud try interval, but at least every hour


### PR DESCRIPTION
```2022-01-25 14:48:06,343 - ERROR    - (metricomdist) - gateway.metrics_controller - Error sending metrics to Cloud: Maximum recursion level reached```