### PR TITLE
Relaxed timeouts for events and updates

### DIFF
--- a/src/cloud/cloud_api_client.py
+++ b/src/cloud/cloud_api_client.py
@@ -77,7 +77,7 @@ class CloudAPIClient(object):
             response = self._session.post(events_endpoint,
                                           params=query_params,
                                           data={'events': json.dumps([event.serialize() for event in events])},
-                                          timeout=2,
+                                          timeout=5,
                                           verify=System.get_operating_system().get('ID') != System.OS.ANGSTROM)
             if not response:
                 raise APIException('Error while sending events to {}. HTTP Status: {}'.format(self._hostname, response.status_code))

--- a/src/gateway/update_controller.py
+++ b/src/gateway/update_controller.py
@@ -1057,7 +1057,7 @@ class UpdateController(object):
         if metadata is None:
             logger.info('Downloading firmware metadata for {0} {1}'.format(firmware_type, version))
             response = requests.get(self._get_update_firmware_metadata_url(firmware_type, version),
-                                    timeout=2,
+                                    timeout=5,
                                     verify=System.get_operating_system().get('ID') != System.OS.ANGSTROM)
             if response.status_code != 200:
                 raise ValueError('Failed to get firmware metadata for {0} {1}'.format(firmware_type, version))


### PR DESCRIPTION
Gateways on slow or high latency connections might have improved experience using these new timeouts.