### PR TITLE
Update input actions

### DIFF
--- a/src/gateway/hal/mappers_core/input.py
+++ b/src/gateway/hal/mappers_core/input.py
@@ -81,8 +81,8 @@ class InputMapper(object):
                     basic_actions += actions
                     if len(basic_actions) == 2 and basic_actions[0] in [163, 164]:
                         return 242 if basic_actions[0] == 163 else 241, []
-                if orm_object.basic_action_release.is_execute_group_action:
-                    basic_actions += [236, 0, 2, orm_object.basic_action_release.device_nr, 236, 255]
+            if orm_object.basic_action_release.is_execute_group_action:
+                basic_actions += [236, 0, 2, orm_object.basic_action_release.device_nr, 236, 255]
             if orm_object.input_link.enable_2s_press:
                 if orm_object.basic_action_2s_press.is_execute_group_action:
                     basic_actions = [207, orm_object.basic_action_2s_press.device_nr] + basic_actions
@@ -113,7 +113,8 @@ class InputMapper(object):
             return data
 
         # The input is configured, changing defaults
-        data['input_link'].update({'dimming_up': False,
+        data['input_link'].update({'output_id': 0,
+                                   'dimming_up': False,
                                    'enable_press_and_release': False,
                                    'enable_1s_press': False,
                                    'enable_2s_press': False,
@@ -170,7 +171,9 @@ class InputMapper(object):
                 if basic_actions[0] == 2:
                     data['basic_action_press'] = BasicAction(action_type=19, action=0, device_nr=basic_actions[1])
                 else:
-                    data['input_link']['enable_2s_press'] = True
+                    # An active 2s press will also implictly enable release, so the explicit release must be off
+                    data['input_link'].update({'enable_press_and_release': False,
+                                               'enable_2s_press': True})
                     data['basic_action_2s_press'] = BasicAction(action_type=19, action=0, device_nr=basic_actions[1])
             return data
 

--- a/testing/unittests/gateway_tests/mappers/input_test.py
+++ b/testing/unittests/gateway_tests/mappers/input_test.py
@@ -91,6 +91,7 @@ class InputCoreMapperTest(unittest.TestCase):
     def test_actions_delayed_press(self):
         orm = InputCoreMapperTest._dto_to_orm(action=240, basic_actions=[207, 1])
         self._validate_orm(orm,
+                           output_id=0,
                            in_use=True,
                            enable_2s_press=True,
                            basic_action_2s_press=True)
@@ -106,6 +107,7 @@ class InputCoreMapperTest(unittest.TestCase):
     def test_actions_press(self):
         orm = InputCoreMapperTest._dto_to_orm(action=240, basic_actions=[2, 1])
         self._validate_orm(orm,
+                           output_id=0,
                            in_use=True,
                            enable_press_and_release=True,
                            basic_action_press=True)
@@ -121,6 +123,7 @@ class InputCoreMapperTest(unittest.TestCase):
     def test_actions_release(self):
         orm = InputCoreMapperTest._dto_to_orm(action=240, basic_actions=[236, 0, 2, 1, 236, 255])
         self._validate_orm(orm,
+                           output_id=0,
                            in_use=True,
                            enable_press_and_release=True,
                            basic_action_release=True)
@@ -136,6 +139,7 @@ class InputCoreMapperTest(unittest.TestCase):
     def test_actions_press_release(self):
         orm = InputCoreMapperTest._dto_to_orm(action=240, basic_actions=[2, 1, 236, 0, 2, 2, 236, 255])
         self._validate_orm(orm,
+                           output_id=0,
                            in_use=True,
                            enable_press_and_release=True,
                            basic_action_press=True,
@@ -154,9 +158,10 @@ class InputCoreMapperTest(unittest.TestCase):
     def test_actions_short_long_press(self):
         orm = InputCoreMapperTest._dto_to_orm(action=240, basic_actions=[207, 1, 236, 0, 2, 2, 236, 255])
         self._validate_orm(orm,
+                           output_id=0,
                            in_use=True,
                            enable_2s_press=True,
-                           enable_press_and_release=True,
+                           enable_press_and_release=False,
                            basic_action_2s_press=True,
                            basic_action_release=True)
         self.assertEqual(BasicAction(action_type=19, action=0, device_nr=1), orm.basic_action_2s_press)


### PR DESCRIPTION
* Output ID is 0 when not in use (except while completely not in use)
* Don't enable "press and release" when "2s press" is already active