### PR TITLE
BE-211 thermostat group sync

### DIFF
--- a/src/gateway/thermostat/gateway/thermostat_controller_gateway.py
+++ b/src/gateway/thermostat/gateway/thermostat_controller_gateway.py
@@ -643,6 +643,8 @@ class ThermostatControllerGateway(ThermostatController):
                         valve.delay = thermostat_group_dto.pump_delay
                         valve.save()
         self._thermostat_config_changed()
+        if self._sync_thread:
+            self._sync_thread.request_single_run()
 
     def remove_thermostat_groups(self, thermostat_group_ids):  # type: (List[int]) -> None
         thermostats = Thermostat.select().where(Thermostat.thermostat_group_id << thermostat_group_ids)


### PR DESCRIPTION
Settings like the pump delay has influence over the control logic, so
that needs to be refreshed.