### PR TITLE
commit sensors immediately when creating

### DIFF
--- a/src/gateway/sensor_controller.py
+++ b/src/gateway/sensor_controller.py
@@ -241,6 +241,7 @@ class SensorController(BaseController):
             raise ValueError('Plugin sensor id {} is invalid'.format(sensor.id))
         if sensor in db.dirty:
             changed = True
+        db.commit()  # explicit commit here because of id allocation
         return sensor, changed
 
     def get_sensors_status(self):  # type: () -> List[SensorStatusDTO]


### PR DESCRIPTION
This is necessary since the python code explicitly allocates the
database ids and otherwise multiple new sensors will receive the same
id.