### PR TITLE
resolve linked shutters based on shutter configuration

### DIFF
--- a/testing/unittests/mocked_core_helper.py
+++ b/testing/unittests/mocked_core_helper.py
@@ -53,7 +53,7 @@ class MockedCore(object):
         self.controller = MasterCoreController()
         self.write_log = []
 
-    def _do_command(self, command, fields, timeout=None):
+    def _do_command(self, command, fields, timeout=None, bypass_blockers=None):
         _ = timeout
         instruction = ''.join(str(chr(c)) for c in command.instruction)
         if instruction == 'MR':


### PR DESCRIPTION
This fixes issues when unlinking shutters that are not configured with
the default one-to-one mapping (eg. created with cli)